### PR TITLE
Update pipeline and build tools

### DIFF
--- a/.github/workflows/auto_check_build_on_main.yml
+++ b/.github/workflows/auto_check_build_on_main.yml
@@ -25,11 +25,11 @@ env:
   DEPLOYED_BASE_URL: 'https://spiges.github.io/handbook-test/'
   DEPLOYED_BASE_NAME: 'handbook-test'
   # Versions
-  HUGO_VERSION: "0.122.0"
+  HUGO_VERSION: "0.124.1"
   GO_VERSION: "1.22"
-  NODE_VERSION: "20.11.0"
-  DART_SASS_VERSION: "1.71.0"
-        
+  NODE_VERSION: "20.12.1"
+  DART_SASS_VERSION: "latest/stable" # Only one stable version available with through Snap. It is not possible to select a specific version for an extended period.
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install Dart Sass
         if: success()
-        run: sudo snap install dart-sass --channel=stable/${{ env.DART_SASS_VERSION }}
+        run: sudo snap install dart-sass --channel=${{ env.DART_SASS_VERSION }}
 
       - name: Checkout
         if: success()

--- a/.github/workflows/auto_check_build_on_main.yml
+++ b/.github/workflows/auto_check_build_on_main.yml
@@ -26,9 +26,9 @@ env:
   DEPLOYED_BASE_NAME: 'handbook-test'
   # Versions
   HUGO_VERSION: "0.124.1"
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.22.2"
   NODE_VERSION: "20.12.1"
-  DART_SASS_VERSION: "latest/stable" # Only one stable version available with through Snap. It is not possible to select a specific version for an extended period.
+  DART_SASS_VERSION: "latest/stable" # Only one stable version available through Snap. It is not possible to select a specific version for an extended period.
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/auto_check_build_on_main.yml
+++ b/.github/workflows/auto_check_build_on_main.yml
@@ -24,6 +24,11 @@ env:
   KEEP_TARGET_HISTORY: false
   DEPLOYED_BASE_URL: 'https://spiges.github.io/handbook-test/'
   DEPLOYED_BASE_NAME: 'handbook-test'
+  # Versions
+  HUGO_VERSION: "0.122.0"
+  GO_VERSION: "1.22"
+  NODE_VERSION: "20.11.0"
+  DART_SASS_VERSION: "1.71.0"
         
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -40,22 +45,20 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-        HUGO_VERSION: 0.122.0
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${{ env.HUGO_VERSION }}/hugo_extended_${{ env.HUGO_VERSION }}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb    
 
-      - name: Install Dart Sass Embedded
+      - name: Install Dart Sass
         if: success()
-        run: sudo snap install dart-sass-embedded
+        run: sudo snap install dart-sass --channel=stable/${{ env.DART_SASS_VERSION }}
 
       - name: Checkout
         if: success()
@@ -67,7 +70,7 @@ jobs:
         if: success()
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.0'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Clear npm cache
         if: success()

--- a/.github/workflows/auto_check_build_on_main.yml
+++ b/.github/workflows/auto_check_build_on_main.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
+          cache: false # to avoid Warning: "Restore cache failed: Dependencies file is not found in /home/runner/work/handbook/handbook. Supported file pattern: go.sum"
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install Hugo CLI

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,9 +7,9 @@ on:
 env:
   # Versions
   HUGO_VERSION: "0.124.1"
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.22.2"
   NODE_VERSION: "20.12.1"
-  DART_SASS_VERSION: "latest/stable"
+  DART_SASS_VERSION: "latest/stable" # Only one stable version available through Snap. It is not possible to select a specific version for an extended period.
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -78,7 +78,7 @@ jobs:
     if: always() && success()
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Pages
         if: success()
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Setup Node.js
         if: success()

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,6 +4,13 @@ name: Release Documentation
 on:
   workflow_dispatch:
 
+env:
+  # Versions
+  HUGO_VERSION: "0.122.0"
+  GO_VERSION: "1.22"
+  NODE_VERSION: "20.11.0"
+  DART_SASS_VERSION: "1.71.0"
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -69,22 +76,20 @@ jobs:
     needs: [check_git_tag]
     runs-on: ubuntu-latest
     if: always() && success()
-    env:
-      HUGO_VERSION: 0.122.0
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${{ env.HUGO_VERSION }}/hugo_extended_${{ env.HUGO_VERSION }}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
-      - name: Install Dart Sass Embedded
+      - name: Install Dart Sass
         if: success()
-        run: sudo snap install dart-sass-embedded
+        run: sudo snap install dart-sass --channel=stable/${{ env.DART_SASS_VERSION }}
 
       - name: Checkout
         if: success()
@@ -101,7 +106,7 @@ jobs:
         if: success()
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Clear npm cache
         if: success()

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
+          cache: false # to avoid Warning "Restore cache failed: Dependencies file is not found in /home/runner/work/handbook/handbook. Supported file pattern: go.sum"
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install Hugo CLI

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -6,10 +6,10 @@ on:
 
 env:
   # Versions
-  HUGO_VERSION: "0.122.0"
+  HUGO_VERSION: "0.124.1"
   GO_VERSION: "1.22"
-  NODE_VERSION: "20.11.0"
-  DART_SASS_VERSION: "1.71.0"
+  NODE_VERSION: "20.12.1"
+  DART_SASS_VERSION: "latest/stable"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install Dart Sass
         if: success()
-        run: sudo snap install dart-sass --channel=stable/${{ env.DART_SASS_VERSION }}
+        run: sudo snap install dart-sass --channel=${{ env.DART_SASS_VERSION }}
 
       - name: Checkout
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+node_modules*/
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -140,7 +140,7 @@ body {
                 white-space: nowrap;
                 padding: $ob-spacing-default;
 
-                > ul {
+                >ul {
                     display: inline-flex;
                     flex-direction: row;
                     align-items: center;
@@ -148,7 +148,7 @@ body {
                     padding: 0;
                     list-style: none;
 
-                    > li > a {
+                    >li>a {
                         padding: 0.375rem 0.75rem;
                         color: $ob-gray-800;
                         background-color: transparent;
@@ -177,7 +177,7 @@ body {
         .layout-navigation {
             flex-grow: 1;
 
-            > nav > ul {
+            >nav>ul {
                 height: 100%;
                 position: relative;
                 display: flex;
@@ -189,12 +189,12 @@ body {
                 background-color: $ob-gray-100;
                 box-shadow: inset 0 -10px 10px -10px $ob-gray-300;
 
-                > li {
+                >li {
                     &:first-child {
                         margin-left: 0;
                     }
 
-                    > a {
+                    >a {
                         border-right: 1px solid $ob-gray-300;
                         background-color: transparent;
                         color: $ob-gray-800;
@@ -214,6 +214,10 @@ body {
                 }
             }
         }
+    }
+
+    .layout-header ul>li>a {
+        text-decoration: none;
     }
 
     .layout-wrapper {
@@ -262,10 +266,10 @@ body {
                     margin: 0;
                     padding-left: 0;
 
-                    > li {
+                    >li {
                         display: list-item;
 
-                        > a {
+                        >a {
                             font-weight: 700;
                             text-decoration: none;
                         }
@@ -276,347 +280,359 @@ body {
     }
 }
 
-    .td-sidebar {
-        background-color: $ob-white;
+.td-sidebar {
+    background-color: $ob-white;
 
-        .td-sidebar__inner {
-            top: 0 !important;
-            padding-top: 4rem !important;
+    .td-sidebar__inner {
+        top: 0 !important;
+        padding-top: 4rem !important;
 
-            .td-sidebar__search {
-                padding: 0 !important;
-            }
+        .td-sidebar__search {
+            padding: 0 !important;
+        }
 
-            nav.td-sidebar-nav {
-                top: 0;
+        nav.td-sidebar-nav {
+            top: 0;
+            margin: 0;
+            padding: 0;
+
+            .ul-0,
+            .ul-1,
+            .ul-2,
+            .ul-3,
+            .ul-4 {
                 margin: 0;
-                padding: 0;
+                padding: 0 !important;
 
-                .ul-0,
-                .ul-1,
-                .ul-2,
-                .ul-3,
-                .ul-4 {
+                li {
                     margin: 0;
-                    padding: 0 !important;
+                    padding: 0;
 
-                    li {
-                        margin: 0;
-                        padding: 0;
+                    a {
+                        margin: 0 !important;
+                        padding: $ob-spacing-xs $ob-spacing-default !important;
+                        font-weight: 400;
+                        color: $ob-gray-800 !important;
+                        border-left: 5px solid transparent;
+                        border-bottom: 1px solid $ob-gray-200 !important;
 
+                        &:hover,
+                        &:focus,
+                        &:active {
+                            background-color: $ob-gray-100;
+                            border-left: 5px solid $ob-venetian-red;
+                        }
+                    }
+
+                    &.active-path {
                         a {
-                            margin: 0 !important;
-                            padding: $ob-spacing-xs $ob-spacing-default !important;
-                            font-weight: 400;
-                            color: $ob-gray-800 !important;
-                            border-left: 5px solid transparent;
-                            border-bottom: 1px solid $ob-gray-200 !important;
-
-                            &:hover,
-                            &:focus,
-                            &:active {
-                                background-color: $ob-gray-100;
-                                border-left: 5px solid $ob-venetian-red;
-                            }
+                            font-weight: 600;
+                            background-color: $ob-gray-300;
+                            border-left: 5px solid $ob-venetian-red;
                         }
 
-                        &.active-path {
-                            a {
-                                font-weight: 600;
-                                background-color: $ob-gray-300;
-                                border-left: 5px solid $ob-venetian-red;
-                            }
+                        ul {
+                            li:not(.active-path) a {
+                                font-weight: 400;
+                                background-color: transparent;
+                                border-left: 5px solid transparent;
 
-                            ul {
-                                li:not(.active-path) a {
-                                    font-weight: 400;
-                                    background-color: transparent;
-                                    border-left: 5px solid transparent;
-
-                                    &:hover,
-                                    &:focus,
-                                    &:active {
-                                        background-color: $ob-gray-100;
-                                        border-left: 5px solid $ob-venetian-red;
-                                    }
+                                &:hover,
+                                &:focus,
+                                &:active {
+                                    background-color: $ob-gray-100;
+                                    border-left: 5px solid $ob-venetian-red;
                                 }
                             }
                         }
                     }
                 }
+            }
 
-                .ul-2 {
-                    li {
-                        a {
-                            padding-left: $ob-spacing-xl !important;
-                            font-size: 90%;
-                        }
+            .ul-2 {
+                li {
+                    a {
+                        padding-left: $ob-spacing-xl !important;
+                        font-size: 90%;
                     }
                 }
+            }
 
-                .ul-3 {
-                    li {
-                        a {
-                            padding-left: $ob-spacing-xl + $ob-spacing-sm !important;
-                            font-size: 90%;
-                        }
+            .ul-3 {
+                li {
+                    a {
+                        padding-left: $ob-spacing-xl + $ob-spacing-sm !important;
+                        font-size: 90%;
                     }
                 }
+            }
 
-                .ul-4 {
-                    li {
-                        a {
-                            padding-left: $ob-spacing-xl + $ob-spacing-default !important;
-                            font-size: 90%;
-                        }
+            .ul-4 {
+                li {
+                    a {
+                        padding-left: $ob-spacing-xl + $ob-spacing-default !important;
+                        font-size: 90%;
                     }
                 }
             }
         }
     }
+}
 
-    .td-search__input:not(:focus) {
-        background: #d5d5d5;
+.td-search__input:not(:focus) {
+    background: #d5d5d5;
+}
+
+aside.d-none {
+    padding-top: 2.5em;
+}
+
+#Logo {
+    width: 216px;
+    height: 55px;
+}
+
+.bg-dark {
+    background: #f2f2f2 !important;
+}
+
+details {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    background-color: #e6e6e6;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    max-width: 80%;
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+}
+
+summary {
+    color: $ob-venetian-red;
+    font-weight: 700;
+    font-size: 1.35rem;
+    margin-bottom: 0.5rem;
+}
+
+a {
+    color: $ob-primary-500;
+
+    &:hover,
+    &:visited {
+        color: $ob-primary-700;
+    }
+}
+
+.table {
+    margin: $ob-spacing-xl 0;
+    display: table;
+    max-width: 80%;
+    font-size: .875rem;
+    font-weight: 400;
+    line-height: 1.42857;
+    letter-spacing: .25px;
+
+    td th {
+        border-top: 1px solid #d5d5d5;
+        border-bottom: 1px solid $ob-gray-300;
+        padding: 8px 16px;
+        text-align: inherit;
     }
 
-    aside.d-none {
-        padding-top: 2.5em;
+    th {
+        font-size: 1rem;
     }
 
-    #Logo {
-        width: 216px;
-        height: 55px;
+    thead tr:first-child th {
+        border-top: none;
     }
 
-    .bg-dark {
-        background: #f2f2f2 !important;
-    }
+    tbody {
+        tr:nth-child(odd) {
+            background-color: $ob-gray-100;
+        }
 
-    details {
-        padding-top: 0.75rem;
-        padding-bottom: 0.75rem;
-        background-color: #e6e6e6;
-        padding-right: 1rem;
-        padding-left: 1rem;
-        max-width: 80%;
-        border-radius: 8px;
-        margin-bottom: 0.75rem;
-    }
-
-    summary {
-        color: $ob-venetian-red;
-        font-weight: 700;
-        font-size: 1.35rem;
-        margin-bottom: 0.5rem;
-    }
-
-    a {
-        color: $ob-primary-500;
-
-        &:hover,
-        &:visited {
-            color: $ob-primary-700;
+        tr:hover,
+        tr.ob-active {
+            background-color: #f2f7fa;
         }
     }
 
-    .table {
-        margin: $ob-spacing-xl 0;
-        display: table;
-        max-width: 80%;
-        font-size: .875rem;
+    &.roles {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 600px;
+        }
+    }
+
+    &.workflow {
+
+        tr>th:nth-child(3),
+        tr>td:nth-child(3) {
+            max-width: 500px;
+        }
+    }
+
+    &.gui {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 400px;
+        }
+    }
+
+    &.entry-fields {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 400px;
+        }
+    }
+
+    &.swagger {
+
+        tr>th:nth-child(3),
+        tr>td:nth-child(3) {
+            max-width: 500px;
+        }
+    }
+
+    &.eiam {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 600px;
+        }
+    }
+
+    &.weblink1 {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 500px;
+        }
+    }
+
+    &.weblink2 {
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 400px;
+        }
+    }
+
+    &.regex {
+
+        tr>th:nth-child(1),
+        tr>td:nth-child(1),
+        tr>th:nth-child(2),
+        tr>td:nth-child(2) {
+            max-width: 350px;
+        }
+    }
+
+    &.partner {
+
+        tr>th:nth-child(1),
+        tr>td:nth-child(1) {
+            max-width: 65px;
+        }
+
+        tr>th:nth-child(4),
+        tr>td:nth-child(4) {
+            max-width: 400px;
+        }
+
+        tr>th:nth-child(2),
+        tr>td:nth-child(2),
+        tr>th:nth-child(5),
+        tr>td:nth-child(5) {
+            max-width: 180px;
+        }
+    }
+}
+
+.alert {
+    display: flex;
+    padding: 0 !important;
+    width: 100%;
+    border-radius: 0 !important;
+    border: none !important;
+
+    .alert-icon {
+        font-size: 2em;
+        padding: 8px 8px 0;
+        text-align: center;
+        color: #fff;
+
+        .icon-wrapper {
+            -webkit-user-select: none;
+            user-select: none;
+            background-repeat: no-repeat;
+            display: inline-block;
+            fill: currentColor;
+            height: 1em;
+            width: 1em;
+            overflow: hidden;
+
+            svg {
+                display: block;
+            }
+        }
+    }
+
+    .alert-content {
+        padding: 16px;
+        flex-grow: 1;
         font-weight: 400;
-        line-height: 1.42857;
-        letter-spacing: .25px;
 
-        td th {
-            border-top: 1px solid #d5d5d5;
-            border-bottom: 1px solid $ob-gray-300;
-            padding: 8px 16px;
-            text-align: inherit;
-        }
-
-        th {
-            font-size: 1rem;
-        }
-
-        thead tr:first-child th {
-            border-top: none;
-        }
-
-        tbody {
-            tr:nth-child(odd) {
-                background-color: $ob-gray-100;
-            }
-
-            tr:hover, tr.ob-active {
-                background-color: #f2f7fa;
-            }
-        }
-
-        &.roles {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 600px;
-            }
-        }
-
-        &.workflow {
-            tr > th:nth-child(3),
-            tr > td:nth-child(3) {
-                max-width: 500px;
-            }
-        }
-
-        &.gui {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 400px;
-            }
-        }
-
-        &.entry-fields {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 400px;
-            }
-        }
-
-        &.swagger {
-            tr > th:nth-child(3),
-            tr > td:nth-child(3) {
-                max-width: 500px;
-            }
-        }
-
-        &.eiam {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 600px;
-            }
-        }
-
-        &.weblink1 {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 500px;
-            }
-        }
-
-        &.weblink2 {
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 400px;
-            }
-        }
-
-        &.regex {
-            tr > th:nth-child(1),
-            tr > td:nth-child(1),
-            tr > th:nth-child(2),
-            tr > td:nth-child(2) {
-                max-width: 350px;
-            }
-        }
-
-        &.partner {
-            tr > th:nth-child(1),
-            tr > td:nth-child(1) {
-                max-width: 65px;
-            }
-
-            tr > th:nth-child(4),
-            tr > td:nth-child(4) {
-                max-width: 400px;
-            }
-
-            tr > th:nth-child(2),
-            tr > td:nth-child(2),
-            tr > th:nth-child(5),
-            tr > td:nth-child(5) {
-                max-width: 180px;
-            }
+        .alert-heading {
+            color: $ob-gray-800 !important;
         }
     }
 
-    .alert {
-        display: flex;
-        padding: 0 !important;
-        width: 100%;
-        border-radius: 0 !important;
-        border: none !important;
+    &.alert- {
 
-        .alert-icon {
-            font-size: 2em;
-            padding: 8px 8px 0;
-            text-align: center;
-            color: #fff;
+        &primary,
+        &info {
+            background-color: #cce0eb;
 
-            .icon-wrapper {
-                -webkit-user-select: none;
-                user-select: none;
-                background-repeat: no-repeat;
-                display: inline-block;
-                fill: currentColor;
-                height: 1em;
-                width: 1em;
-                overflow: hidden;
-
-                svg {
-                    display: block;
-                }
+            .alert-icon {
+                background-color: #006699;
             }
         }
 
-        .alert-content {
-            padding: 16px;
-            flex-grow: 1;
-            font-weight: 400;
+        &success {
+            background-color: #c3e8cd;
 
-            .alert-heading {
-                color: $ob-gray-800 !important;
+            .alert-icon {
+                background-color: #00813a;
             }
         }
 
-        &.alert- {
-            &primary,
-            &info {
-                background-color: #cce0eb;
+        &warning {
+            background-color: #fee3b5;
 
-                .alert-icon {
-                    background-color: #006699;
-                }
+            .alert-icon {
+                background-color: #e75e00;
             }
+        }
 
-            &success {
-                background-color: #c3e8cd;
+        &error {
+            background-color: #fbcad2;
 
-                .alert-icon {
-                    background-color: #00813a;
-                }
-            }
-
-            &warning {
-                background-color: #fee3b5;
-
-                .alert-icon {
-                    background-color: #e75e00;
-                }
-            }
-
-            &error {
-                background-color: #fbcad2;
-
-                .alert-icon {
-                    background-color: #b00020;
-                }
+            .alert-icon {
+                background-color: #b00020;
             }
         }
     }
+}
 
-    .toc {
-        column-count: 3;
-        max-width: 80%;
-    }
+.toc {
+    column-count: 3;
+    max-width: 80%;
+}
 
 .collapsible-content {
     display: none;
@@ -636,4 +652,3 @@ body {
     font-size: 16px;
     border: 1px solid #ccc;
 }
-

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/spiges/handbook
 
-go 1.22
-
-require github.com/google/docsy v0.8.0 // indirect
+require (
+	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
+	github.com/google/docsy v0.9.1 // indirect
+	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/spiges/handbook
 
+go 1.22.2
+
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
 	github.com/google/docsy v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
 github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 h1:Uv1z5EqCfmiK4IHUwT0m3h/u/WCk+kpRfxvAZhpC7Gc=
-github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.8.0 h1:RgHyKRTo8YwScMThrf01Ky2yCGpUS1hpkspwNv6szT4=
-github.com/google/docsy v0.8.0/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
-github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
-github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
+github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "CC BY-NC-ND 4.0",
       "devDependencies": {
-        "autoprefixer": "^10.4.14",
+        "autoprefixer": "^10.4.19",
         "cross-env": "^7.0.3",
-        "hugo-extended": "0.122.0",
+        "hugo-extended": "0.124.1",
         "postcss-cli": "^11.0.0"
       }
     },
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+      "version": "10.4.19",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
       "dev": true,
       "funding": [
         {
@@ -194,12 +194,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
+        "browserslist": "^4.23.0",
+        "caniuse-lite": "^1.0.30001599",
+        "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -266,9 +270,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "dev": true,
       "funding": [
         {
@@ -278,13 +282,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -388,9 +396,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001464",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
-      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==",
+      "version": "1.0.30001606",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
       "dev": true,
       "funding": [
         {
@@ -400,6 +408,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -718,9 +730,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
-      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
+      "version": "1.4.729",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+      "integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -846,16 +858,16 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "dev": true,
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-constants": {
@@ -1060,9 +1072,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.122.0.tgz",
-      "integrity": "sha512-f9kPVSKxk5mq62wmw1tbhg5CV7n93Tbt7jZoy+C3yfRlEZhGqBlxaEJ3MeeNoilz3IPy5STHB7R0Bdhuap7mHA==",
+      "version": "0.124.1",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.124.1.tgz",
+      "integrity": "sha512-GaF/wOTSrfobyVwd46/0KSwVPQ76ZEU4BnKj5rrLyYtGDwFM4UXGdtTa9z8xMI4DF9RvCV6UIvU0cvkcDEl+aA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1423,9 +1435,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -2269,9 +2281,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -2281,6 +2293,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -2288,7 +2304,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.14",
+    "autoprefixer": "^10.4.19",
     "cross-env": "^7.0.3",
-    "hugo-extended": "0.122.0",
+    "hugo-extended": "0.124.1",
     "postcss-cli": "^11.0.0"
   }
 }


### PR DESCRIPTION
- Node updated to 20.12.1
- Go updated to 1.22.2
- Hugo-extended updated to 0.124.1
- Dart-sass-embedded replaced by Dart-sass (latest/stable)
- Docsy updated to 0.9.1
- Font-Awesome updated to 6.5.2
- Bootstrap updated to 5.3.3
- auto-prefixed updated to ^10.4.19
- actions/setup-go updated to v5
- actions/configure-pages updated to v5
- Warning issues of pipeline fixed (go cache)
- Tool versions centralized in the YAML file to ease the management
- New CSS rule, related to the tabs in the header layout (Language + tabs), added to fix issue because of update