### PR TITLE
[#43] - New settings file added

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": "always"
+    },
+    "markdownlint.config": {
+        "MD024": { "siblings_only": true},
+    }
+}


### PR DESCRIPTION
- New JSON settings file added, allowing to configure some things, such as markdownlint.
- "MD024" rule added with option `siblings_only` enabled, allowing to use a file with multiple times a same title in a same level without warnings (suitable for `changelog` file)