### PR TITLE
RC 41 improve collapsible block

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,19 @@
         "source.fixAll.markdownlint": "always"
     },
     "markdownlint.config": {
+        "MD007": {
+            "indent": 4  // Number of spaces for indenting unordered lists
+        },
+        "MD010": false,  // Allow the use of tabs
         "MD024": { "siblings_only": true},
-    }
+        "MD033": {
+            "allowed_elements": ["collapsibleGroupCommand", "collapsibleBlock", "insertImage", "alert"]
+        },
+    },
+    "[scss]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 2,
+        "editor.detectIndentation": false
+      }
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,654 +7,661 @@
 @import "shortcodes/collapsible-group-command.scss";
 
 html {
-    line-height: 1.5;
+  line-height: 1.5;
 }
 
 body {
-    margin: 0;
-    word-break: break-word;
-    color: $ob-gray-800;
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+  margin: 0;
+  word-break: break-word;
+  color: $ob-gray-800;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
 }
 
 .td-content {
-    h1 {
-        font-size: 3rem;
-        font-weight: 300;
-        line-height: 1.25;
-        letter-spacing: -0.5px;
-    }
+  h1 {
+    font-size: 3rem;
+    font-weight: 300;
+    line-height: 1.25;
+    letter-spacing: -0.5px;
+  }
 
-    h2 {
-        font-size: 2.5rem;
-        font-weight: 300;
-        line-height: 1.2;
-        letter-spacing: -0.5px;
-    }
+  h2 {
+    font-size: 2.5rem;
+    font-weight: 300;
+    line-height: 1.2;
+    letter-spacing: -0.5px;
+  }
 
-    h3 {
-        font-size: 2rem;
-        font-weight: 400;
-        line-height: 1.375;
-        letter-spacing: 0.18px;
-    }
+  h3 {
+    font-size: 2rem;
+    font-weight: 400;
+    line-height: 1.375;
+    letter-spacing: 0.18px;
+  }
 
-    h4 {
-        font-size: 1.75rem;
-        font-weight: 400;
-        line-height: 1.285715;
-        letter-spacing: 0.1px;
-    }
+  h4 {
+    font-size: 1.75rem;
+    font-weight: 400;
+    line-height: 1.285715;
+    letter-spacing: 0.1px;
+  }
 
-    h5 {
-        font-size: 1.25rem;
-        font-weight: 500;
-        line-height: 1.4;
-        letter-spacing: 0.2px;
-    }
+  h5 {
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0.2px;
+  }
 
-    h6 {
-        font-size: 1.125rem;
-        font-weight: 500;
-        line-height: 1.333333;
-        letter-spacing: 0.2px;
-    }
+  h6 {
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.333333;
+    letter-spacing: 0.2px;
+  }
 }
 
 .viewport {
-    height: 100vh;
-    overflow-x: hidden;
+  height: 100vh;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+
+  .layout-header {
     display: flex;
     flex-direction: column;
+    background-color: #fff;
+    z-index: 101;
 
-    .layout-header {
+    .header-wrapper {
+      display: flex;
+      position: relative;
+      width: 100%;
+      background-color: inherit;
+      border-bottom: 5px solid $ob-venetian-red;
+
+      .header-title {
+        position: relative;
         display: flex;
-        flex-direction: column;
-        background-color: #fff;
-        z-index: 101;
+        flex: 1;
+        flex-flow: row nowrap;
+        margin-right: auto;
+        min-width: 0;
+        overflow: hidden;
 
-        .header-wrapper {
-            display: flex;
-            position: relative;
-            width: 100%;
-            background-color: inherit;
-            border-bottom: 5px solid $ob-venetian-red;
+        .layout-brand {
+          display: flex;
 
-            .header-title {
-                position: relative;
-                display: flex;
-                flex: 1;
-                flex-flow: row nowrap;
-                margin-right: auto;
-                min-width: 0;
-                overflow: hidden;
+          @media (max-width: 767.99px) {
+            flex-direction: column;
+          }
 
-                .layout-brand {
-                    display: flex;
+          flex: auto;
+          flex-direction: row;
+          align-items: center;
+          min-width: 0;
+          padding: $ob-spacing-default;
 
-                    @media (max-width: 767.99px) {
-                        flex-direction: column;
-                    }
+          .layout-logo {
+            width: 216px;
+            height: 55px;
+            margin-right: $ob-spacing-default;
 
-                    flex: auto;
-                    flex-direction: row;
-                    align-items: center;
-                    min-width: 0;
-                    padding: $ob-spacing-default;
+            svg {
+              margin: 0;
+            }
+          }
 
-                    .layout-logo {
-                        width: 216px;
-                        height: 55px;
-                        margin-right: $ob-spacing-default;
+          .layout-title {
+            display: block;
+            flex: 1;
+            font-size: 1.65rem;
+            line-height: 34px;
+            font-weight: 300;
+            color: $ob-gray-500;
+            padding-left: $ob-spacing-default;
+            border-left: 1px solid #e5e5e5;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
 
-                        svg {
-                            margin: 0;
-                        }
-                    }
-
-                    .layout-title {
-                        display: block;
-                        flex: 1;
-                        font-size: 1.65rem;
-                        line-height: 34px;
-                        font-weight: 300;
-                        color: $ob-gray-500;
-                        padding-left: $ob-spacing-default;
-                        border-left: 1px solid #e5e5e5;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-
-                        @media (max-width: 767.99px) {
-                            border-left: 0px;
-                        }
-
-                        .layout-title-link {
-                            color: $ob-gray-500;
-                            text-decoration: none;
-                        }
-                    }
-                }
+            @media (max-width: 767.99px) {
+              border-left: 0px;
             }
 
-            .header-controls {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                flex-wrap: wrap;
-                white-space: nowrap;
-                padding: $ob-spacing-default;
+            .layout-title-link {
+              color: $ob-gray-500;
+              text-decoration: none;
+            }
+          }
+        }
+      }
+
+      .header-controls {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        white-space: nowrap;
+        padding: $ob-spacing-default;
 
         > ul {
-                    display: inline-flex;
-                    flex-direction: row;
-                    align-items: center;
-                    margin: 0;
-                    padding: 0;
-                    list-style: none;
+          display: inline-flex;
+          flex-direction: row;
+          align-items: center;
+          margin: 0;
+          padding: 0;
+          list-style: none;
 
           > li > a {
-                        padding: 0.375rem 0.75rem;
-                        color: $ob-gray-800;
-                        background-color: transparent;
-                        border: none transparent;
-                        border-radius: 0;
-                        user-select: none;
-                        transition: background-color 0.25s ease-in-out;
-                        cursor: default;
+            padding: 0.375rem 0.75rem;
+            color: $ob-gray-800;
+            background-color: transparent;
+            border: none transparent;
+            border-radius: 0;
+            user-select: none;
+            transition: background-color 0.25s ease-in-out;
+            cursor: default;
 
-                        &.active,
-                        &:hover,
-                        &:focus {
-                            background-color: $ob-gray-200;
-                        }
-                    }
-                }
+            &.active,
+            &:hover,
+            &:focus {
+              background-color: $ob-gray-200;
             }
-
-            @media (max-width: 991.99px) {
-                .header-controls .language-switcher {
-                    display: none;
-                }
-            }
+          }
         }
+      }
 
-        .layout-navigation {
-            flex-grow: 1;
+      @media (max-width: 991.99px) {
+        .header-controls .language-switcher {
+          display: none;
+        }
+      }
+    }
+
+    .layout-navigation {
+      flex-grow: 1;
 
       > nav > ul {
-                height: 100%;
-                position: relative;
-                display: flex;
-                flex-flow: column wrap;
-                flex-direction: row;
-                margin: 0;
-                padding: 0;
-                list-style: none;
-                background-color: $ob-gray-100;
-                box-shadow: inset 0 -10px 10px -10px $ob-gray-300;
+        height: 100%;
+        position: relative;
+        display: flex;
+        flex-flow: column wrap;
+        flex-direction: row;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        background-color: $ob-gray-100;
+        box-shadow: inset 0 -10px 10px -10px $ob-gray-300;
 
         > li {
-                    &:first-child {
-                        margin-left: 0;
-                    }
+          &:first-child {
+            margin-left: 0;
+          }
 
           > a {
-                        border-right: 1px solid $ob-gray-300;
-                        background-color: transparent;
-                        color: $ob-gray-800;
-                        display: inline-flex;
-                        padding: $ob-spacing-default;
+            border-right: 1px solid $ob-gray-300;
+            background-color: transparent;
+            color: $ob-gray-800;
+            display: inline-flex;
+            padding: $ob-spacing-default;
 
-                        &.active {
-                            background-color: $ob-white;
-                            font-weight: 600;
-                        }
-
-                        &:hover,
-                        &:active {
-                            background-color: $ob-gray-300;
-                        }
-                    }
-                }
+            &.active {
+              background-color: $ob-white;
+              font-weight: 600;
             }
+
+            &:hover,
+            &:active {
+              background-color: $ob-gray-300;
+            }
+          }
         }
+      }
     }
+  }
 
   .layout-header ul > li > a {
-        text-decoration: none;
+    text-decoration: none;
+  }
+
+  .layout-wrapper {
+    display: flex;
+    overflow: auto;
+    flex-direction: column;
+    flex: 1 1 auto;
+
+    .td-main {
+      margin-left: 3px;
+      margin-right: 3px;
+
+      .content-wrapper {
+        max-width: 1440px;
+
+        aside,
+        main {
+          padding: $ob-spacing-default;
+        }
+      }
     }
 
-    .layout-wrapper {
-        display: flex;
-        overflow: auto;
-        flex-direction: column;
-        flex: 1 1 auto;
+    footer {
+      position: relative;
+      display: flex;
+      flex-flow: column wrap;
+      flex-direction: row;
+      padding: $ob-spacing-xs $ob-spacing-default !important;
+      border-top: 1px solid $ob-gray-300;
+      background-color: $ob-gray-100;
+      color: $ob-gray-700;
+      font-size: 0.8rem;
+      min-height: unset;
 
-        .td-main {
-            margin-left: 3px;
-            margin-right: 3px;
+      .footer-item {
+        padding: $ob-spacing-xs 0;
 
-            .content-wrapper {
-                max-width: 1440px;
-
-                aside,
-                main {
-                    padding: $ob-spacing-default;
-                }
-            }
+        &.footer-item-info {
+          margin-right: $ob-spacing-default;
+          flex: 1;
         }
 
-        footer {
-            position: relative;
-            display: flex;
-            flex-flow: column wrap;
-            flex-direction: row;
-            padding: $ob-spacing-xs $ob-spacing-default !important;
-            border-top: 1px solid $ob-gray-300;
-            background-color: $ob-gray-100;
-            color: $ob-gray-700;
-            font-size: 0.8rem;
-            min-height: unset;
-
-            .footer-item {
-                padding: $ob-spacing-xs 0;
-
-                &.footer-item-info {
-                    margin-right: $ob-spacing-default;
-                    flex: 1;
-                }
-
-                &.footer-item-links {
-                    display: flex;
-                    list-style: none;
-                    margin: 0;
-                    padding-left: 0;
+        &.footer-item-links {
+          display: flex;
+          list-style: none;
+          margin: 0;
+          padding-left: 0;
 
           > li {
-                        display: list-item;
+            display: list-item;
 
             > a {
-                            font-weight: 700;
-                            text-decoration: none;
-                        }
-                    }
-                }
+              font-weight: 700;
+              text-decoration: none;
             }
+          }
         }
+      }
     }
+  }
 }
 
 .td-sidebar {
-    background-color: $ob-white;
+  background-color: $ob-white;
 
-    .td-sidebar__inner {
-        top: 0 !important;
-        padding-top: 4rem !important;
+  .td-sidebar__inner {
+    top: 0 !important;
+    padding-top: 4rem !important;
 
-        .td-sidebar__search {
-            padding: 0 !important;
-        }
-
-        nav.td-sidebar-nav {
-            top: 0;
-            margin: 0;
-            padding: 0;
-
-            .ul-0,
-            .ul-1,
-            .ul-2,
-            .ul-3,
-            .ul-4 {
-                margin: 0;
-                padding: 0 !important;
-
-                li {
-                    margin: 0;
-                    padding: 0;
-
-                    a {
-                        margin: 0 !important;
-                        padding: $ob-spacing-xs $ob-spacing-default !important;
-                        font-weight: 400;
-                        color: $ob-gray-800 !important;
-                        border-left: 5px solid transparent;
-                        border-bottom: 1px solid $ob-gray-200 !important;
-
-                        &:hover,
-                        &:focus,
-                        &:active {
-                            background-color: $ob-gray-100;
-                            border-left: 5px solid $ob-venetian-red;
-                        }
-                    }
-
-                    &.active-path {
-                        a {
-                            font-weight: 600;
-                            background-color: $ob-gray-300;
-                            border-left: 5px solid $ob-venetian-red;
-                        }
-
-                        ul {
-                            li:not(.active-path) a {
-                                font-weight: 400;
-                                background-color: transparent;
-                                border-left: 5px solid transparent;
-
-                                &:hover,
-                                &:focus,
-                                &:active {
-                                    background-color: $ob-gray-100;
-                                    border-left: 5px solid $ob-venetian-red;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            .ul-2 {
-                li {
-                    a {
-                        padding-left: $ob-spacing-xl !important;
-                        font-size: 90%;
-                    }
-                }
-            }
-
-            .ul-3 {
-                li {
-                    a {
-                        padding-left: $ob-spacing-xl + $ob-spacing-sm !important;
-                        font-size: 90%;
-                    }
-                }
-            }
-
-            .ul-4 {
-                li {
-                    a {
-                        padding-left: $ob-spacing-xl + $ob-spacing-default !important;
-                        font-size: 90%;
-                    }
-                }
-            }
-        }
+    .td-sidebar__search {
+      padding: 0 !important;
     }
+
+    nav.td-sidebar-nav {
+      top: 0;
+      margin: 0;
+      padding: 0;
+
+      .ul-0,
+      .ul-1,
+      .ul-2,
+      .ul-3,
+      .ul-4 {
+        margin: 0;
+        padding: 0 !important;
+
+        li {
+          margin: 0;
+          padding: 0;
+
+          a {
+            margin: 0 !important;
+            padding: $ob-spacing-xs $ob-spacing-default !important;
+            font-weight: 400;
+            color: $ob-gray-800 !important;
+            border-left: 5px solid transparent;
+            border-bottom: 1px solid $ob-gray-200 !important;
+
+            &:hover,
+            &:focus,
+            &:active {
+              background-color: $ob-gray-100;
+              border-left: 5px solid $ob-venetian-red;
+            }
+          }
+
+          &.active-path {
+            a {
+              font-weight: 600;
+              background-color: $ob-gray-300;
+              border-left: 5px solid $ob-venetian-red;
+            }
+
+            ul {
+              li:not(.active-path) a {
+                font-weight: 400;
+                background-color: transparent;
+                border-left: 5px solid transparent;
+
+                &:hover,
+                &:focus,
+                &:active {
+                  background-color: $ob-gray-100;
+                  border-left: 5px solid $ob-venetian-red;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      .ul-2 {
+        li {
+          a {
+            padding-left: $ob-spacing-xl !important;
+            font-size: 90%;
+          }
+        }
+      }
+
+      .ul-3 {
+        li {
+          a {
+            padding-left: $ob-spacing-xl + $ob-spacing-sm !important;
+            font-size: 90%;
+          }
+        }
+      }
+
+      .ul-4 {
+        li {
+          a {
+            padding-left: $ob-spacing-xl + $ob-spacing-default !important;
+            font-size: 90%;
+          }
+        }
+      }
+    }
+  }
 }
 
 .td-search__input:not(:focus) {
-    background: #d5d5d5;
+  background: #d5d5d5;
 }
 
 aside.d-none {
-    padding-top: 2.5em;
+  padding-top: 2.5em;
 }
 
 #Logo {
-    width: 216px;
-    height: 55px;
+  width: 216px;
+  height: 55px;
 }
 
 .bg-dark {
-    background: #f2f2f2 !important;
+  background: #f2f2f2 !important;
 }
 
 details {
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-    background-color: #e6e6e6;
-    padding-right: 1rem;
-    padding-left: 1rem;
-    max-width: 80%;
-    border-radius: 8px;
-    margin-bottom: 0.75rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  background-color: #e6e6e6;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  max-width: 80%;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
 }
 
 summary {
-    color: $ob-venetian-red;
-    font-weight: 700;
-    font-size: 1.35rem;
-    margin-bottom: 0.5rem;
+  color: $ob-venetian-red;
+  font-weight: 700;
+  font-size: 1.35rem;
+  margin-bottom: 0.5rem;
 }
 
 a {
-    color: $ob-primary-500;
+  color: $ob-primary-500;
 
-    &:hover,
-    &:visited {
-        color: $ob-primary-700;
-    }
+  &:hover,
+  &:visited {
+    color: $ob-primary-700;
+  }
 }
 
 .table {
-    margin: $ob-spacing-xl 0;
-    display: table;
-    max-width: 80%;
+  margin: $ob-spacing-xl 0;
+  display: table;
+  max-width: 80%;
   font-size: 0.875rem;
-    font-weight: 400;
-    line-height: 1.42857;
+  font-weight: 400;
+  line-height: 1.42857;
   letter-spacing: 0.25px;
 
-    td th {
-        border-top: 1px solid #d5d5d5;
-        border-bottom: 1px solid $ob-gray-300;
-        padding: 8px 16px;
-        text-align: inherit;
+  td th {
+    border-top: 1px solid #d5d5d5;
+    border-bottom: 1px solid $ob-gray-300;
+    padding: 8px 16px;
+    text-align: inherit;
+  }
+
+  th {
+    font-size: 1rem;
+  }
+
+  thead tr:first-child th {
+    border-top: none;
+  }
+
+  tbody {
+    tr:nth-child(odd) {
+      background-color: $ob-gray-100;
     }
 
-    th {
-        font-size: 1rem;
+    tr:hover,
+    tr.ob-active {
+      background-color: #f2f7fa;
     }
+  }
 
-    thead tr:first-child th {
-        border-top: none;
-    }
-
-    tbody {
-        tr:nth-child(odd) {
-            background-color: $ob-gray-100;
-        }
-
-        tr:hover,
-        tr.ob-active {
-            background-color: #f2f7fa;
-        }
-    }
-
-    &.roles {
+  &.roles {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 600px;
-        }
+      max-width: 600px;
     }
+  }
 
-    &.workflow {
+  &.workflow {
     tr > th:nth-child(3),
     tr > td:nth-child(3) {
-            max-width: 500px;
-        }
+      max-width: 500px;
     }
+  }
 
-    &.gui {
+  &.gui {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 400px;
-        }
+      max-width: 400px;
     }
+  }
 
-    &.entry-fields {
+  &.entry-fields {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 400px;
-        }
+      max-width: 400px;
     }
+  }
 
-    &.swagger {
+  &.swagger {
     tr > th:nth-child(3),
     tr > td:nth-child(3) {
-            max-width: 500px;
-        }
+      max-width: 500px;
     }
+  }
 
-    &.eiam {
+  &.eiam {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 600px;
-        }
+      max-width: 600px;
     }
+  }
 
-    &.weblink1 {
+  &.weblink1 {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 500px;
-        }
+      max-width: 500px;
     }
+  }
 
-    &.weblink2 {
+  &.weblink2 {
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 400px;
-        }
+      max-width: 400px;
     }
+  }
 
-    &.regex {
+  &.regex {
     tr > th:nth-child(1),
     tr > td:nth-child(1),
     tr > th:nth-child(2),
     tr > td:nth-child(2) {
-            max-width: 350px;
-        }
+      max-width: 350px;
     }
+  }
 
-    &.partner {
+  &.partner {
     tr > th:nth-child(1),
     tr > td:nth-child(1) {
-            max-width: 65px;
-        }
+      max-width: 65px;
+    }
 
     tr > th:nth-child(4),
     tr > td:nth-child(4) {
-            max-width: 400px;
-        }
+      max-width: 400px;
+    }
 
     tr > th:nth-child(2),
     tr > td:nth-child(2),
     tr > th:nth-child(5),
     tr > td:nth-child(5) {
-            max-width: 180px;
-        }
+      max-width: 180px;
     }
+  }
 }
 
 .alert {
-    display: flex;
-    padding: 0 !important;
-    width: 100%;
-    border-radius: 0 !important;
-    border: none !important;
+  display: flex;
+  padding: 0 !important;
+  width: 100%;
+  border-radius: 0 !important;
+  border: none !important;
 
-    .alert-icon {
-        font-size: 2em;
-        padding: 8px 8px 0;
-        text-align: center;
-        color: #fff;
+  .alert-icon {
+    font-size: 2em;
+    padding: 8px 8px 0;
+    text-align: center;
+    color: #fff;
 
-        .icon-wrapper {
-            -webkit-user-select: none;
-            user-select: none;
-            background-repeat: no-repeat;
-            display: inline-block;
-            fill: currentColor;
-            height: 1em;
-            width: 1em;
-            overflow: hidden;
+    .icon-wrapper {
+      -webkit-user-select: none;
+      user-select: none;
+      background-repeat: no-repeat;
+      display: inline-block;
+      fill: currentColor;
+      height: 1em;
+      width: 1em;
+      overflow: hidden;
 
-            svg {
-                display: block;
-            }
-        }
+      svg {
+        display: block;
+      }
+    }
+  }
+
+  .alert-content {
+    padding: 16px;
+    flex-grow: 1;
+    font-weight: 400;
+
+    .alert-heading {
+      color: $ob-gray-800 !important;
+    }
+  }
+
+  &.alert- {
+    &primary,
+    &info {
+      background-color: #cce0eb;
+
+      .alert-icon {
+        background-color: #006699;
+      }
     }
 
-    .alert-content {
-        padding: 16px;
-        flex-grow: 1;
-        font-weight: 400;
+    &success {
+      background-color: #c3e8cd;
 
-        .alert-heading {
-            color: $ob-gray-800 !important;
-        }
+      .alert-icon {
+        background-color: #00813a;
+      }
     }
 
-    &.alert- {
-        &primary,
-        &info {
-            background-color: #cce0eb;
+    &warning {
+      background-color: #fee3b5;
 
-            .alert-icon {
-                background-color: #006699;
-            }
-        }
-
-        &success {
-            background-color: #c3e8cd;
-
-            .alert-icon {
-                background-color: #00813a;
-            }
-        }
-
-        &warning {
-            background-color: #fee3b5;
-
-            .alert-icon {
-                background-color: #e75e00;
-            }
-        }
-
-        &error {
-            background-color: #fbcad2;
-
-            .alert-icon {
-                background-color: #b00020;
-            }
-        }
+      .alert-icon {
+        background-color: #e75e00;
+      }
     }
+
+    &error {
+      background-color: #fbcad2;
+
+      .alert-icon {
+        background-color: #b00020;
+      }
+    }
+  }
 }
 
 .toc {
-    column-count: 3;
-    max-width: 80%;
+  column-count: 3;
+  max-width: 80%;
 }
 
 img.edge {
-    border: 2px solid gray;
+  border: 2px solid gray;
 }
 
 .max-w-90 {
-    max-width: 90%;
+  max-width: 90%;
 }
 
 img.img_full {
-    max-width: 950px;
+  max-width: 950px;
 }
 
 .two_column {
-    display: flex; 
-    justify-content: space-between; 
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 
 .left_col {
-    flex: 1; 
-    padding-right: 10px;
+  flex: 1;
+  padding-right: 10px;
 }
 
 .right_col {
-    flex: 1; 
-    padding-left: 10px;
+  flex: 1;
+  padding-left: 10px;
+}
+
+// This selector allows removing bottom margin on all the `p` elements inside `li` elements.
+// This selector is used for the paragraphs of the FAQ.
+// TODO: this selector is too general and must be improved by adding another selector specifically related to the FAQ.
+li > p {
+  margin-bottom: 0px;
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -148,7 +148,7 @@ body {
                 white-space: nowrap;
                 padding: $ob-spacing-default;
 
-                >ul {
+        > ul {
                     display: inline-flex;
                     flex-direction: row;
                     align-items: center;
@@ -156,7 +156,7 @@ body {
                     padding: 0;
                     list-style: none;
 
-                    >li>a {
+          > li > a {
                         padding: 0.375rem 0.75rem;
                         color: $ob-gray-800;
                         background-color: transparent;
@@ -185,7 +185,7 @@ body {
         .layout-navigation {
             flex-grow: 1;
 
-            >nav>ul {
+      > nav > ul {
                 height: 100%;
                 position: relative;
                 display: flex;
@@ -197,12 +197,12 @@ body {
                 background-color: $ob-gray-100;
                 box-shadow: inset 0 -10px 10px -10px $ob-gray-300;
 
-                >li {
+        > li {
                     &:first-child {
                         margin-left: 0;
                     }
 
-                    >a {
+          > a {
                         border-right: 1px solid $ob-gray-300;
                         background-color: transparent;
                         color: $ob-gray-800;
@@ -224,7 +224,7 @@ body {
         }
     }
 
-    .layout-header ul>li>a {
+  .layout-header ul > li > a {
         text-decoration: none;
     }
 
@@ -274,10 +274,10 @@ body {
                     margin: 0;
                     padding-left: 0;
 
-                    >li {
+          > li {
                         display: list-item;
 
-                        >a {
+            > a {
                             font-weight: 700;
                             text-decoration: none;
                         }
@@ -435,10 +435,10 @@ a {
     margin: $ob-spacing-xl 0;
     display: table;
     max-width: 80%;
-    font-size: .875rem;
+  font-size: 0.875rem;
     font-weight: 400;
     line-height: 1.42857;
-    letter-spacing: .25px;
+  letter-spacing: 0.25px;
 
     td th {
         border-top: 1px solid #d5d5d5;
@@ -467,95 +467,85 @@ a {
     }
 
     &.roles {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 600px;
         }
     }
 
     &.workflow {
-
-        tr>th:nth-child(3),
-        tr>td:nth-child(3) {
+    tr > th:nth-child(3),
+    tr > td:nth-child(3) {
             max-width: 500px;
         }
     }
 
     &.gui {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 400px;
         }
     }
 
     &.entry-fields {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 400px;
         }
     }
 
     &.swagger {
-
-        tr>th:nth-child(3),
-        tr>td:nth-child(3) {
+    tr > th:nth-child(3),
+    tr > td:nth-child(3) {
             max-width: 500px;
         }
     }
 
     &.eiam {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 600px;
         }
     }
 
     &.weblink1 {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 500px;
         }
     }
 
     &.weblink2 {
-
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 400px;
         }
     }
 
     &.regex {
-
-        tr>th:nth-child(1),
-        tr>td:nth-child(1),
-        tr>th:nth-child(2),
-        tr>td:nth-child(2) {
+    tr > th:nth-child(1),
+    tr > td:nth-child(1),
+    tr > th:nth-child(2),
+    tr > td:nth-child(2) {
             max-width: 350px;
         }
     }
 
     &.partner {
-
-        tr>th:nth-child(1),
-        tr>td:nth-child(1) {
+    tr > th:nth-child(1),
+    tr > td:nth-child(1) {
             max-width: 65px;
         }
 
-        tr>th:nth-child(4),
-        tr>td:nth-child(4) {
+    tr > th:nth-child(4),
+    tr > td:nth-child(4) {
             max-width: 400px;
         }
 
-        tr>th:nth-child(2),
-        tr>td:nth-child(2),
-        tr>th:nth-child(5),
-        tr>td:nth-child(5) {
+    tr > th:nth-child(2),
+    tr > td:nth-child(2),
+    tr > th:nth-child(5),
+    tr > td:nth-child(5) {
             max-width: 180px;
         }
     }
@@ -601,7 +591,6 @@ a {
     }
 
     &.alert- {
-
         &primary,
         &info {
             background-color: #cce0eb;
@@ -642,30 +631,30 @@ a {
     max-width: 80%;
 }
 
-img.edge{
+img.edge {
     border: 2px solid gray;
 }
 
-.max-w-90{
+.max-w-90 {
     max-width: 90%;
 }
 
-img.img_full{
+img.img_full {
     max-width: 950px;
 }
 
-.two_column{
+.two_column {
     display: flex; 
     justify-content: space-between; 
-    align-items: center
+  align-items: center;
 }
 
-.left_col{
+.left_col {
     flex: 1; 
     padding-right: 10px;
 }
 
-.right_col{
+.right_col {
     flex: 1; 
     padding-left: 10px;
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,3 +1,11 @@
+// Importing utility classes
+@import "utilities/paddings";
+// Abstracts (variables, mixins)
+@import "abstracts/mixins";
+// Shortcodes
+@import "shortcodes/collapsible-block.scss";
+@import "shortcodes/collapsible-group-command.scss";
+
 html {
     line-height: 1.5;
 }
@@ -644,42 +652,6 @@ img.edge{
 
 img.img_full{
     max-width: 950px;
-}
-
-
-@mixin collapsible-button-hover-effect {
-    &:hover {
-      text-decoration: underline;
-    }
-}
-
-%collapsible-button {
-    padding: 5px 10px;
-    border: none;
-    background-color: unset;
-    text-align: left;
-    color: blue;
-    
-    @include collapsible-button-hover-effect;
-}
-
-.collapsible-group-command {
-    .collapsible-group-command__button {
-        @extend %collapsible-button;
-    }
-}
-
-.collapsible-block {
-    .collapsible-block__content {
-        display: none;
-        padding: 10px;
-        margin-top: 5px;
-        width: 100%;
-    }
-    
-    .collapsible-block__button {
-        @extend %collapsible-button;
-    }
 }
 
 .two_column{

--- a/assets/scss/abstracts/_mixins.scss
+++ b/assets/scss/abstracts/_mixins.scss
@@ -1,0 +1,18 @@
+@mixin hover-point-cursor {
+  cursor: pointer;
+}
+
+@mixin hover-effect {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+@mixin link-hover-effect-button {
+  border: none;
+  background-color: unset;
+  text-align: left;
+  color: blue;
+
+  @include hover-effect;
+}

--- a/assets/scss/shortcodes/collapsible-block.scss
+++ b/assets/scss/shortcodes/collapsible-block.scss
@@ -1,0 +1,16 @@
+.collapsible-block {
+  .collapsible-block__content {
+    display: none;
+    padding: 0px 10px 20px 10px;
+    margin-top: 5px;
+    width: 100%;
+  }
+
+  .collapsible-block__icon {
+    @include hover-point-cursor;
+  }
+
+  .collapsible-block__button {
+    @include link-hover-effect-button;
+  }
+}

--- a/assets/scss/shortcodes/collapsible-group-command.scss
+++ b/assets/scss/shortcodes/collapsible-group-command.scss
@@ -1,0 +1,9 @@
+.collapsible-group-command {
+  .collapsible-group-command__button {
+    @include link-hover-effect-button;
+  }
+
+  .collapsible-group-command__icon {
+    @include hover-point-cursor;
+  }
+}

--- a/assets/scss/utilities/_paddings.scss
+++ b/assets/scss/utilities/_paddings.scss
@@ -1,0 +1,3 @@
+.padding-bottom-20 {
+  padding-bottom: 20px;
+}

--- a/content/de/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/de/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -7,19 +7,21 @@ type: docs
 keywords: []
 ---
 
-Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Rollen">}}
+Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Rollen" tooltipEnabled="true">}}
 
-1. Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat? {{<collapsibleBlock groupId="Rollen">}}
+1. Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat? {{<collapsibleBlock customCollapsedText="Antwort..." customExpandedText="Antwort..." groupId="Rollen" tooltipEnabled="true" tooltipText="Erweitern/reduzieren Sie">}}
 Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär an seine zuständige kantonale Erhebungsstelle.
 {{</collapsibleBlock>}}
 
 2. Wie sieht die Rolle der Kantone, insbesondere der kantonalen Erhebungspartner, zukünftig aus? {{<collapsibleBlock groupId="Rollen">}}
-<ul>
-	<li> Die kantonalen Erhebungsstellen wirken bei der BFS Erhebung mit wie bisher (Grundgesamtheit, Koordination und Kommunikation Spital, Mahnwesen usw.). </li>
-	<li> Das zuständige kantonale Gesundheitsamt gibt neu Ende Juli die Daten der Spitalunternehmen auf ihrem Hoheitsgebiet für die Nutzung nach KVG auf der SpiGes Plattform frei. </li>
-</ul>
-{{</collapsibleBlock>}}
 
+- Die kantonalen Erhebungsstellen wirken bei der BFS Erhebung mit wie bisher (Grundgesamtheit, Koordination und Kommunikation Spital, Mahnwesen usw.).
+
+- Das zuständige kantonale Gesundheitsamt gibt neu Ende Juli die Daten der Spitalunternehmen auf ihrem Hoheitsgebiet für die Nutzung nach KVG auf der SpiGes Plattform frei.
+
+{{</collapsibleBlock>}}
+<!-- markdownlint doesn't see that 1 et 2 are already used above -->
+<!-- markdownlint-disable MD029 -->
 3. Es gibt in SpiGes freiwillige Variablen, welche gemäss Vorgabe des Kantons ausgefüllt werden können. Bis wann muss der Kanton den Betrieben bzw. dem BFS mitteilen, welche Variablen ausgefüllt werden sollen. Ist der Kanton hier frei in der Entscheidung, welche freiwilligen Elemente ausgefüllt werden müssen?{{<collapsibleBlock groupId="Rollen">}}
 Die Kantone teilen ihren Spitälern die Bereitstellung der freiwilligen Variablen (z. B. op_gln) früh genug mit, damit diese ab den Daten 2024 im Spitalsystem erfasst werden. Der Kanton beschliesst gemäss seinen Vorgaben im Gesundheitsbereich, welche bei diesen Variablen spezifischer als die nationalen Vorgaben sein können.
 {{</collapsibleBlock>}}
@@ -35,4 +37,3 @@ Das BFS ist mit dem ANQ in Kontakt, um die SpiGes Variablen und Formate abzuglei
 6. Können Sie mir die gesetzliche Grundlage nennen, die die Krankenhäuser verpflichtet, die Statistik zu übermitteln? {{<collapsibleBlock groupId="Rollen">}}
 Gemäss Art. 23 des Bundesgesetzes vom 18. März 1994 über die Krankenversicherung (KVG; SR 832.10), Art. 6 Abs. 4 des Bundesstatistikgesetzes vom 9. Oktober 1992 (BStatG; SR 431.01), Art. 6 Abs. 1 der Verordnung vom 30. Juni 1993 über die Durchführung von statistischen Erhebungen des Bundes (SR 431. 012.1) und den Bestimmungen über die Krankenhausstatistik und der Medizinischen Statistik im Anhang der genannten Verordnung sind alle Krankenhäuser verpflichtet, dem Bundesamt für Statistik die erforderlichen Daten in der vorgeschriebenen Form und innerhalb der festgesetzten Frist zu liefern.
 {{</collapsibleBlock>}}
-

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -18,3 +18,7 @@ other = "Klicken Sie hier, um zu reduzieren..."
 other = "Alle erweitern"
 [collapse_all]
 other = "Alle reduzieren"
+[click_to_expand_collapse]
+other = "Klicken Sie hier, um zu erweitern/reduzieren"
+[click_to_expand_collapse_all]
+other = "Klicken Sie hier, um alle zu erweitern/reduzieren"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -18,3 +18,7 @@ other = "Click here to collapse..."
 other = "Expand all"
 [collapse_all]
 other = "Collapse all"
+[click_to_expand_collapse]
+other = "Click here to expand/collapse"
+[click_to_expand_collapse_all]
+other = "Click here to expand/collapse all"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -18,3 +18,7 @@ other = "Cliquez ici pour réduire..."
 other = "Développer tout"
 [collapse_all]
 other = "Réduire tout"
+[click_to_expand_collapse]
+other = "Cliquez ici pour développer/réduire"
+[click_to_expand_collapse_all]
+other = "Cliquez ici pour tout développer/réduire"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -18,3 +18,7 @@ other = "Clicca qui per comprimere..."
 other = "Espandere tutto"
 [collapse_all]
 other = "Comprimere tutto"
+[click_to_expand_collapse]
+other = "Clicca qui per espandere/comprimere"
+[click_to_expand_collapse_all]
+other = "Clicca qui per espandere/comprimere tutto"

--- a/layouts/shortcodes/collapsibleBlock.html
+++ b/layouts/shortcodes/collapsibleBlock.html
@@ -1,19 +1,30 @@
 <!-- collapsible.html -->
 {{ $groupId := .Get "groupId" | default ""}}
 {{ $class := .Get "class" | default ""}}
+{{ $collapsedText := .Get "customCollapsedText" | default (T "click_to_expand") }}  <!-- Fetch collapsedText or use default -->
+{{ $expandedText := .Get "customExpandedText" | default (T "click_to_collapse") }}  <!-- Fetch expandedText or use default -->
+{{ $tooltipText := .Get "tooltipText" | default ""}}
+{{ $tooltipEnabled := .Get "tooltipEnabled" | default false }}
 <div class="collapsible-block {{$class}}" 
      group-id="{{$groupId}}"
-     collapsed-text="{{ T "click_to_expand" }}"
-     expanded-text="{{ T "click_to_collapse" }}"
+     collapsed-text="{{$collapsedText}}"
+     expanded-text="{{$expandedText}}"
 >
     <span>
-        <i class="collapsible-block__icon fas"></i>
-        <button class="collapsible-block__button"></button>
+        {{ if $tooltipEnabled }}
+            {{ with $tooltipText }}
+                <i class="collapsible-block__icon fas" data-bs-toggle="tooltip" data-bs-placement="top" title="{{$tooltipText}}"></i>
+            {{ else }}
+                <i class="collapsible-block__icon fas" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ T "click_to_expand_collapse" }}"></i>
+            {{ end }}
+        {{ else }}
+            <i class="collapsible-block__icon fas"></i>
+        {{ end }}
+        <button type="button" class="collapsible-block__button"></button>
     </span>
     
     <div class="collapsible-block__content">
-        {{ .Inner }}
+        {{ .Inner | markdownify }}
     </div>
 </div>
-
     

--- a/layouts/shortcodes/collapsibleGroupCommand.html
+++ b/layouts/shortcodes/collapsibleGroupCommand.html
@@ -1,12 +1,24 @@
 <!-- collapsibleGroupCommand.html -->
 {{ $groupId := .Get "groupId" | default ""}}
 {{ $class := .Get "class" | default ""}}
+{{ $collapsedText := .Get "customCollapsedText" | default (T "expand_all") }}  <!-- Fetch collapsedText or use default -->
+{{ $expandedText := .Get "customExpandedText" | default (T "collapse_all") }}  <!-- Fetch expandedText or use default -->
+{{ $tooltipText := .Get "tooltipText" | default ""}}
+{{ $tooltipEnabled := .Get "tooltipEnabled" | default false }}
 <span class="collapsible-group-command {{$class}}"
-     collapsed-text="{{ T "expand_all" }}"
-     expanded-text="{{ T "collapse_all" }}"
+     collapsed-text="{{$collapsedText}}"
+     expanded-text="{{$expandedText}}"
      group-id="{{$groupId}}"
 >
-    <i class="collapsible-group-command__icon fas"></i>
+    {{ if $tooltipEnabled }}
+        {{ with $tooltipText }}
+            <i class="collapsible-group-command__icon fas" data-bs-toggle="tooltip" data-bs-placement="top" title="{{$tooltipText}}"></i>
+        {{ else }}
+            <i class="collapsible-group-command__icon fas" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ T "click_to_expand_collapse_all" }}"></i>
+        {{ end }}
+    {{ else }}
+        <i class="collapsible-group-command__icon fas"></i>
+    {{ end }}
     <button type="button" class="collapsible-group-command__button"></button>
 </span>
     

--- a/static/js/collapsible.js
+++ b/static/js/collapsible.js
@@ -85,6 +85,11 @@ class CollapsibleConstants {
      * Typically, this represents a rightward pointing chevron or arrow.
      */
     static collapseIconClass = "fa-chevron-right";
+
+    /**
+     * The CSS class name allowing to apply a `padding-bottom` of 20px
+     */
+    static paddingBottomClass = "padding-bottom-20";
 }
 
 /**
@@ -171,6 +176,7 @@ class CollapsibleBlock {
      */
     #initialize() {
         this.#buttonElement.addEventListener("click", () => this.toggle());
+        this.#iconElement.addEventListener("click", () => this.toggle());
         this.collapse();
     }
 
@@ -202,6 +208,7 @@ class CollapsibleBlock {
         this.#contentElement.style.display = CollapsibleBlock.#expandedDisplayClass;
         this.#iconElement.classList.remove(CollapsibleConstants.collapseIconClass);
         this.#iconElement.classList.add(CollapsibleConstants.expandIconClass);
+        this.#buttonElement.classList.remove(CollapsibleConstants.paddingBottomClass);
     }
 
     /**
@@ -213,6 +220,7 @@ class CollapsibleBlock {
         this.#contentElement.style.display = CollapsibleBlock.#collapsedDisplayClass;
         this.#iconElement.classList.remove(CollapsibleConstants.expandIconClass);
         this.#iconElement.classList.add(CollapsibleConstants.collapseIconClass);
+        this.#buttonElement.classList.add(CollapsibleConstants.paddingBottomClass);
     }
 }
 
@@ -288,6 +296,7 @@ class CollapsibleGroupCommand {
      */
     #initialize() {
         this.#buttonElement.addEventListener("click", () => this.toggleAll());
+        this.#iconElement.addEventListener("click", () => this.toggleAll());
         this.collapseAll();
     }
 


### PR DESCRIPTION
- A custom title (for expanded and collapsed states) can be set
- Default tooltip, disabled by default, added. A custom tooltip text can be set
- The icon of the expand/collapse action is now clickable and its behavior is the same as clicking on the text
- The style definitions used by the shortcodes moved in other files
- New settings added to improve the linter behavior (markdown and scss)
- Page rollen stakeholder updated by using new stuffs