### PR TITLE
[#48] -  Improve css selector paragraphs faq + new shortcodes added

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MD010": false,  // Allow the use of tabs
         "MD024": { "siblings_only": true},
         "MD033": {
-            "allowed_elements": ["collapsibleGroupCommand", "collapsibleBlock", "insertImage", "alert"]
+            "allowed_elements": ["collapsibleGroupCommand", "collapsibleBlock", "insertImage", "alert", "numberedList", "listItem"]
         },
     },
     "[scss]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,8 @@
                 "alert", 
                 "numberedList", 
                 "listItem", 
-                "faqBlock"
+                "faqBlock",
+                "markdown"
             ]
         },
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,15 @@
         "MD010": false,  // Allow the use of tabs
         "MD024": { "siblings_only": true},
         "MD033": {
-            "allowed_elements": ["collapsibleGroupCommand", "collapsibleBlock", "insertImage", "alert", "numberedList", "listItem"]
+            "allowed_elements": [
+                "collapsibleGroupCommand", 
+                "collapsibleBlock", 
+                "insertImage", 
+                "alert", 
+                "numberedList", 
+                "listItem", 
+                "faqBlock"
+            ]
         },
     },
     "[scss]": {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -654,10 +654,3 @@ img.img_full {
   flex: 1;
   padding-left: 10px;
 }
-
-// This selector allows removing bottom margin on all the `p` elements inside `li` elements.
-// This selector is used for the paragraphs of the FAQ.
-// TODO: this selector is too general and must be improved by adding another selector specifically related to the FAQ.
-li > p {
-  margin-bottom: 0px;
-}

--- a/assets/scss/shortcodes/_collapsible-block.scss
+++ b/assets/scss/shortcodes/_collapsible-block.scss
@@ -1,7 +1,7 @@
 .collapsible-block {
   .collapsible-block__content {
     display: none;
-    padding: 0px 10px 20px 10px;
+    padding: 0px 10px 10px 10px;
     margin-top: 5px;
     width: 100%;
   }

--- a/assets/scss/shortcodes/_faq-block.scss
+++ b/assets/scss/shortcodes/_faq-block.scss
@@ -1,0 +1,7 @@
+.faq-block {
+  // This selector is temporary and aims for the FAQ implementation using direct markdown instead of the new shortcode `numberedList`.
+  // When `numberedList` is used in all the FAQ pages, this selector can be removed.
+  li > p {
+    margin-bottom: 0px;
+  }
+}

--- a/assets/scss/shortcodes/_index.scss
+++ b/assets/scss/shortcodes/_index.scss
@@ -2,3 +2,4 @@
 @import "collapsible-group-command";
 @import "numbered-list";
 @import "list-item";
+@import "faq-block";

--- a/assets/scss/shortcodes/_index.scss
+++ b/assets/scss/shortcodes/_index.scss
@@ -1,2 +1,4 @@
 @import "collapsible-block";
 @import "collapsible-group-command";
+@import "numbered-list";
+@import "list-item";

--- a/assets/scss/shortcodes/_list-item.scss
+++ b/assets/scss/shortcodes/_list-item.scss
@@ -1,0 +1,3 @@
+.list-item {
+  padding-bottom: 25px;
+}

--- a/assets/scss/shortcodes/_numbered-list.scss
+++ b/assets/scss/shortcodes/_numbered-list.scss
@@ -1,0 +1,3 @@
+.numbered-list {
+  visibility: visible;
+}

--- a/content/de/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/de/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -7,34 +7,57 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
+
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Rollen">}}
 
-1. Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat?
+{{<numberedList>}}
+{{<listItem>}}
+Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat?
 {{<collapsibleBlock groupId="Rollen">}}
 Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär an seine zuständige kantonale Erhebungsstelle.
 {{</collapsibleBlock>}}
-<!-- markdownlint doesn't see that 1 et 2 are already used above -->
-<!-- markdownlint-disable MD029 -->
-2. Wie sieht die Rolle der Kantone, insbesondere der kantonalen Erhebungspartner, zukünftig aus? {{<collapsibleBlock groupId="Rollen">}}
+{{</listItem>}}
+
+{{<listItem>}}
+Wie sieht die Rolle der Kantone, insbesondere der kantonalen Erhebungspartner, zukünftig aus?
+{{<collapsibleBlock groupId="Rollen">}}
+{{<markdown>}}
 
 - Die kantonalen Erhebungsstellen wirken bei der BFS Erhebung mit wie bisher (Grundgesamtheit, Koordination und Kommunikation Spital, Mahnwesen usw.).
 
 - Das zuständige kantonale Gesundheitsamt gibt neu Ende Juli die Daten der Spitalunternehmen auf ihrem Hoheitsgebiet für die Nutzung nach KVG auf der SpiGes Plattform frei.
-
+{{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Es gibt in SpiGes freiwillige Variablen, welche gemäss Vorgabe des Kantons ausgefüllt werden können. Bis wann muss der Kanton den Betrieben bzw. dem BFS mitteilen, welche Variablen ausgefüllt werden sollen. Ist der Kanton hier frei in der Entscheidung, welche freiwilligen Elemente ausgefüllt werden müssen?{{<collapsibleBlock groupId="Rollen">}}
+{{<listItem>}}
+Es gibt in SpiGes freiwillige Variablen, welche gemäss Vorgabe des Kantons ausgefüllt werden können. Bis wann muss der Kanton den Betrieben bzw. dem BFS mitteilen, welche Variablen ausgefüllt werden sollen. Ist der Kanton hier frei in der Entscheidung, welche freiwilligen Elemente ausgefüllt werden müssen?
+{{<collapsibleBlock groupId="Rollen">}}
 Die Kantone teilen ihren Spitälern die Bereitstellung der freiwilligen Variablen (z. B. op_gln) früh genug mit, damit diese ab den Daten 2024 im Spitalsystem erfasst werden. Der Kanton beschliesst gemäss seinen Vorgaben im Gesundheitsbereich, welche bei diesen Variablen spezifischer als die nationalen Vorgaben sein können.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Die Spitäler wünschen sich eine Informationsveranstaltung, damit sie einen besseren Überblick über die bevorstehenden Anforderungen erhalten. Ist eine solche vom BFS geplant? {{<collapsibleBlock groupId="Rollen">}}
+{{<listItem>}}
+Die Spitäler wünschen sich eine Informationsveranstaltung, damit sie einen besseren Überblick über die bevorstehenden Anforderungen erhalten. Ist eine solche vom BFS geplant?
+{{<collapsibleBlock groupId="Rollen">}}
 Das BFS hat bereits 4 Infoveranstaltungen für ein breites Publikum durchgeführt, hier haben auch einige Spitäler teilgenommen. H+ hat seine Spitäler jeweils darüber informiert. Da zum jetzigen Zeitpunkt nicht mehr konzeptuelle Fragen, sondern sehr spezifische Themen auftauchen, sieht das BFS einen solchen Grossanlass nicht als das geeignete Instrument an. Das BFS sammelt die eingegangenen Fragen und wird die FAQ auf der SpiGes Webseite hochschalten.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Können künftig auch die Anforderungen des ANQ mit dem XML-File erfüllt werden? {{<collapsibleBlock groupId="Rollen">}}
+{{<listItem>}}
+Können künftig auch die Anforderungen des ANQ mit dem XML-File erfüllt werden?
+{{<collapsibleBlock groupId="Rollen">}}
 Das BFS ist mit dem ANQ in Kontakt, um die SpiGes Variablen und Formate abzugleichen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Können Sie mir die gesetzliche Grundlage nennen, die die Krankenhäuser verpflichtet, die Statistik zu übermitteln? {{<collapsibleBlock groupId="Rollen">}}
+{{<listItem>}}
+Können Sie mir die gesetzliche Grundlage nennen, die die Krankenhäuser verpflichtet, die Statistik zu übermitteln? {{<collapsibleBlock groupId="Rollen">}}
 Gemäss Art. 23 des Bundesgesetzes vom 18. März 1994 über die Krankenversicherung (KVG; SR 832.10), Art. 6 Abs. 4 des Bundesstatistikgesetzes vom 9. Oktober 1992 (BStatG; SR 431.01), Art. 6 Abs. 1 der Verordnung vom 30. Juni 1993 über die Durchführung von statistischen Erhebungen des Bundes (SR 431. 012.1) und den Bestimmungen über die Krankenhausstatistik und der Medizinischen Statistik im Anhang der genannten Verordnung sind alle Krankenhäuser verpflichtet, dem Bundesamt für Statistik die erforderlichen Daten in der vorgeschriebenen Form und innerhalb der festgesetzten Frist zu liefern.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
+{{</numberedList>}}
+
+{{</faqBlock>}}

--- a/layouts/shortcodes/collapsibleBlock.html
+++ b/layouts/shortcodes/collapsibleBlock.html
@@ -23,7 +23,7 @@
     </span>
     
     <div class="collapsible-block__content">
-        {{ .Inner | markdownify }}
+        {{ .Inner }}
     </div>
 </div>
     

--- a/layouts/shortcodes/faqBlock.html
+++ b/layouts/shortcodes/faqBlock.html
@@ -1,0 +1,29 @@
+{{/* 
+  Shortcode for creating a FAQ block with optional custom classes.
+
+  This shortcode generates a `div` element with the class 'faq-block' and allows for additional
+  custom classes to be added. It is designed to encapsulate FAQ content providing a consistent and customizable style.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the `div` element.
+           This parameter is optional and defaults to an empty string if not provided.
+
+  Example:
+    {{<faq-block>}}
+    Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Rollen">}}
+
+    {{<numberedList>}}
+
+    {{<listItem>}}
+    Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat?
+    {{<collapsibleBlock groupId="Rollen">}}
+    Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär an seine zuständige kantonale Erhebungsstelle.
+    {{</collapsibleBlock>}}
+    {{</listItem>}}
+    ...
+    {{</faq-block>}}
+*/}}
+{{ $class := .Get "class" | default ""}}
+<div class="faq-block {{$class}}">
+    {{ .Inner }}
+</div>

--- a/layouts/shortcodes/listItem.html
+++ b/layouts/shortcodes/listItem.html
@@ -1,0 +1,30 @@
+{{/* 
+  Generates a list item with optional custom classes.
+
+  This shortcode creates an list item (`<il>`) HTML element, allowing the user
+  to add custom classes for styling purposes. This shortcode is intended to be used inside `<numberedList>` shortcode.
+
+  The main reason of providing this shortcode is that using markdown numberered list doesn't work well 
+  when shortcodes are used inside a numbered item. Indeed, the HTML result could contain more than one <ol> element.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the `<il>` element.
+           This parameter is optional and defaults to an empty string if not provided.
+
+  Example:
+  To use this shortcode in your content, you can include it like this:
+    {{<numberedList>}}
+
+    {{<listItem>}}
+    Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat?
+    {{<collapsibleBlock groupId="Rollen">}}
+    Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär an seine zuständige kantonale Erhebungsstelle.
+    {{</collapsibleBlock>}}
+    {{</listItem>}}
+    ...
+    {{</numberedList>}}
+*/}}
+{{ $class := .Get "class" | default ""}}
+<li class="list-item {{$class}}">
+    {{ .Inner }}
+</li>

--- a/layouts/shortcodes/markdown.html
+++ b/layouts/shortcodes/markdown.html
@@ -1,0 +1,17 @@
+{{/* 
+  Shortcode for converting Markdown content to HTML.
+
+  This shortcode uses the `markdownify` function to convert Markdown-formatted text
+  within its content to HTML. It's particularly useful for rendering user-provided
+  Markdown content dynamically in templates or in shortcodes which don't markdownify the inner part, 
+  allowing for flexible content management.
+
+  Example:
+  {{<markdown>}}
+      Here is some Markdown content:
+      - **Bold** text
+      - _Italic_ text
+      - An [Example link](http://example.com)
+  {{</markdown>}}
+*/}}
+{{ .Inner | markdownify }}

--- a/layouts/shortcodes/numberedList.html
+++ b/layouts/shortcodes/numberedList.html
@@ -1,0 +1,30 @@
+{{/* 
+  Generates a numbered list with optional custom classes.
+
+  This shortcode creates an ordered list (`<ol>`) HTML element, allowing the user
+  to add custom classes for styling purposes.
+
+  The main reason of providing this shortcode is that using markdown numberered list doesn't work well 
+  when shortcodes are used inside a numbered item. Indeed, the HTML result could contain more than one <ol> element.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the `<ol>` element.
+           This parameter is optional and defaults to an empty string if not provided.
+
+  Example:
+  To use this shortcode in your content, you can include it like this:
+    {{<numberedList>}}
+
+    {{<listItem>}}
+    Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes Erhebung hat?
+    {{<collapsibleBlock groupId="Rollen">}}
+    Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär an seine zuständige kantonale Erhebungsstelle.
+    {{</collapsibleBlock>}}
+    {{</listItem>}}
+    ...
+    {{</numberedList>}}
+*/}}
+{{ $class := .Get "class" | default ""}}
+<ol class="numbered-list {{$class}}">
+    {{ .Inner }}
+</ol>


### PR DESCRIPTION
- New shortcodes (numberedList, listItem, faqBlock, markdown) added
- markdownify removed from collapstibleBlock
- `li > p` selector removed and replaced by a new one in `.faq-block` class
- rollen stakeholder page updated by using new shortcodes