### PR TITLE
[#55] - FAQ updated by using new shortcodes related to numbered list, FAQ block and Markdown

### DIFF
--- a/content/de/FAQ/2_identifikatoren.md
+++ b/content/de/FAQ/2_identifikatoren.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
+{{<numberedList>}}
 1. Die AHVN ist ein Pflichtfeld. Trotzdem wird es Fälle ohne AHV-Nr. geben. Wo ist beschrieben was in diesem Fall in die Variable kommt?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Genau diese Frage ist noch offen. Im Datensatz steht: «Anmerkung: Bezüglich der Personen, die keine AHV-Nummer haben können, sind noch Abklärungen im Gange (vgl. auch Spalte "Anzugeben für").» Kurzfristig ist angedacht, die Variable in diesem Falle leer zu lassen resp. eine Dummy-Nummer anzugeben. Es gab nun aber starken Widerstand dagegen aus einigen Grenzkantonen, weshalb diese Frage langfristig noch genauer abgeklärt wird.
@@ -24,5 +25,5 @@ Bei der Datenübermittlung werden Identifikatoren und Daten separat verschickt. 
 {{<collapsibleBlock groupId="identifikatoren">}}
 Der Kanton kann während der Erhebung zu Plausibilisierungszwecken Daten exportieren, dabei wird die AHVN pseudonymisiert werden.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/2_identifikatoren.md
+++ b/content/de/FAQ/2_identifikatoren.md
@@ -11,19 +11,26 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 {{<numberedList>}}
-1. Die AHVN ist ein Pflichtfeld. Trotzdem wird es Fälle ohne AHV-Nr. geben. Wo ist beschrieben was in diesem Fall in die Variable kommt?
+{{<listItem>}}
+Die AHVN ist ein Pflichtfeld. Trotzdem wird es Fälle ohne AHV-Nr. geben. Wo ist beschrieben was in diesem Fall in die Variable kommt?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Genau diese Frage ist noch offen. Im Datensatz steht: «Anmerkung: Bezüglich der Personen, die keine AHV-Nummer haben können, sind noch Abklärungen im Gange (vgl. auch Spalte "Anzugeben für").» Kurzfristig ist angedacht, die Variable in diesem Falle leer zu lassen resp. eine Dummy-Nummer anzugeben. Es gab nun aber starken Widerstand dagegen aus einigen Grenzkantonen, weshalb diese Frage langfristig noch genauer abgeklärt wird.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Bei der Datenerhebung soll ja die AHVN genutzt werden. Wird die AHVN über die Tarifpartner auch an die Krankenkassen ersichtlich sein werden?
+{{<listItem>}}
+Bei der Datenerhebung soll ja die AHVN genutzt werden. Wird die AHVN über die Tarifpartner auch an die Krankenkassen ersichtlich sein werden?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Bei der Datenübermittlung werden Identifikatoren und Daten separat verschickt. Der Datenkanal ist verschlüsselt. Zur Überprüfung der AHVN wird der «BFS AHVN Validator» eingesetzt. Nachdem die AHVN verschlüsselt worden ist, wird diese auf der gesicherten Identifikatoren Datenbank gespeichert. Während der Bearbeitung der Daten auf der Plattform ist die AHVN somit pseudonymisiert und nicht zusammen mit dem Leistungsdatensatz abgelegt. Die AHVN kann nur verschlüsselt an die Datennut-zer weitergegeben werden. Da diese Datennutzer den Schlüssel nicht kennen, ist für diese die AHVN anonymisiert. Ein Rückschluss auf den Originalwert ist nicht möglich.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Hat der Kanton Zugang zum ID-File der Lieferungen?
+{{<listItem>}}
+Hat der Kanton Zugang zum ID-File der Lieferungen?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Der Kanton kann während der Erhebung zu Plausibilisierungszwecken Daten exportieren, dabei wird die AHVN pseudonymisiert werden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/2_identifikatoren.md
+++ b/content/de/FAQ/2_identifikatoren.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 1. Die AHVN ist ein Pflichtfeld. Trotzdem wird es Fälle ohne AHV-Nr. geben. Wo ist beschrieben was in diesem Fall in die Variable kommt?
@@ -23,3 +24,5 @@ Bei der Datenübermittlung werden Identifikatoren und Daten separat verschickt. 
 {{<collapsibleBlock groupId="identifikatoren">}}
 Der Kanton kann während der Erhebung zu Plausibilisierungszwecken Daten exportieren, dabei wird die AHVN pseudonymisiert werden.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 1. Wie lassen sich die Kosten und Erlöse der gemeinwirtschaftlichen Leistungen in SpiGes erfassen?
@@ -116,3 +117,5 @@ Anhand der Angabe «ktr_typ» wird ein Kostenträger einer ITAR_K-Spalte zugeord
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Um ein ITAR_K ausfüllen zu können, werden die Kosten der ambulanten Fälle summarisch pro KTR Typ (z.B. Tarif Dialyse) abgefüllt.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -106,7 +106,7 @@ Dazu wählen Sie unter ktr_typ den passenden Code der entsprechenden GWL Leistun
 {{</listItem>}}
 
 {{<listItem>}}
-Können fallunabhängige Kostenträger einem Spital (burnr_gesv) angehängt werden anstelle eines Standortes? 
+Können fallunabhängige Kostenträger einem Spital (burnr_gesv) angehängt werden anstelle eines Standortes?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Nein, das ist nicht möglich.
 {{</collapsibleBlock>}}
@@ -116,7 +116,7 @@ Nein, das ist nicht möglich.
 Kann man KTR-Typen auch mehrfach verwenden? Zum Beispiel bei 599 mehrfache Zeilen abliefern mit unterschiedlichem Freitext in der Variable "ktr_beschr" ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Ja, das ist möglich. <br />
-Anhand der Angabe «ktr_typ» wird ein Kostenträger einer ITAR_K-Spalte zugeordnet. Somit muss in der Variable «ktr_typ» einer der vordefinierten Werte verwendet werden. Es ist jedoch möglich mehrere Kostenträger mit demselben KTR-Typ anzugeben, z.B. für den ktr_typ 205 einmal mit dem Freitext «KVG» und einmal mit dem Freitext «MTK» in der Variable «ktr_beschr». Diese beiden Kostenträger werden dann summiert und in der ITAR_K-Spalte «Tagesklinik Kind- & Jugendpsychiatrie» abgebildet. Theoretisch sind auch weitere Aufteilungen technisch möglich, bis auf den ambulanten Fall. Solange alle denselben KTR-Typ aufweisen, werden sie wie beschrieben summiert und abgebildet. 
+Anhand der Angabe «ktr_typ» wird ein Kostenträger einer ITAR_K-Spalte zugeordnet. Somit muss in der Variable «ktr_typ» einer der vordefinierten Werte verwendet werden. Es ist jedoch möglich mehrere Kostenträger mit demselben KTR-Typ anzugeben, z.B. für den ktr_typ 205 einmal mit dem Freitext «KVG» und einmal mit dem Freitext «MTK» in der Variable «ktr_beschr». Diese beiden Kostenträger werden dann summiert und in der ITAR_K-Spalte «Tagesklinik Kind- & Jugendpsychiatrie» abgebildet. Theoretisch sind auch weitere Aufteilungen technisch möglich, bis auf den ambulanten Fall. Solange alle denselben KTR-Typ aufweisen, werden sie wie beschrieben summiert und abgebildet.
 {{</collapsibleBlock>}}
 {{</listItem>}}
 

--- a/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -11,7 +11,8 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 {{<numberedList>}}
-1. Wie lassen sich die Kosten und Erlöse der gemeinwirtschaftlichen Leistungen in SpiGes erfassen?
+{{<listItem>}}
+Wie lassen sich die Kosten und Erlöse der gemeinwirtschaftlichen Leistungen in SpiGes erfassen?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Dazu wählen Sie unter ktr_typ den passenden Code der entsprechenden GWL Leistung aus und tragen die entsprechenden Kosten und Erlöse anhand den in REKOLE® definierten Kostenarten-, bzw. Kostenstellennummern und Erlöskonten ein. Anbei die Liste der unterschiedlichen GWL Typen und dem entsprechenden ktr_typ Code:
 <table class="w-100">
@@ -102,21 +103,29 @@ Dazu wählen Sie unter ktr_typ den passenden Code der entsprechenden GWL Leistun
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Können fallunabhängige Kostenträger einem Spital (burnr_gesv) angehängt werden anstelle eines Standortes? 
+{{<listItem>}}
+Können fallunabhängige Kostenträger einem Spital (burnr_gesv) angehängt werden anstelle eines Standortes? 
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Nein, das ist nicht möglich.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Kann man KTR-Typen auch mehrfach verwenden? Zum Beispiel bei 599 mehrfache Zeilen abliefern mit unterschiedlichem Freitext in der Variable "ktr_beschr" ?
+{{<listItem>}}
+Kann man KTR-Typen auch mehrfach verwenden? Zum Beispiel bei 599 mehrfache Zeilen abliefern mit unterschiedlichem Freitext in der Variable "ktr_beschr" ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Ja, das ist möglich. <br />
 Anhand der Angabe «ktr_typ» wird ein Kostenträger einer ITAR_K-Spalte zugeordnet. Somit muss in der Variable «ktr_typ» einer der vordefinierten Werte verwendet werden. Es ist jedoch möglich mehrere Kostenträger mit demselben KTR-Typ anzugeben, z.B. für den ktr_typ 205 einmal mit dem Freitext «KVG» und einmal mit dem Freitext «MTK» in der Variable «ktr_beschr». Diese beiden Kostenträger werden dann summiert und in der ITAR_K-Spalte «Tagesklinik Kind- & Jugendpsychiatrie» abgebildet. Theoretisch sind auch weitere Aufteilungen technisch möglich, bis auf den ambulanten Fall. Solange alle denselben KTR-Typ aufweisen, werden sie wie beschrieben summiert und abgebildet. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Wird der KTR-Teil auch bei ambulanten Fällen erwartet, oder bezieht sich dieser ebenfalls ausschliesslich auf stationäre Fälle?
+{{<listItem>}}
+Wird der KTR-Teil auch bei ambulanten Fällen erwartet, oder bezieht sich dieser ebenfalls ausschliesslich auf stationäre Fälle?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Um ein ITAR_K ausfüllen zu können, werden die Kosten der ambulanten Fälle summarisch pro KTR Typ (z.B. Tarif Dialyse) abgefüllt.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/de/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
+{{<numberedList>}}
 1. Wie lassen sich die Kosten und Erlöse der gemeinwirtschaftlichen Leistungen in SpiGes erfassen?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Dazu wählen Sie unter ktr_typ den passenden Code der entsprechenden GWL Leistung aus und tragen die entsprechenden Kosten und Erlöse anhand den in REKOLE® definierten Kostenarten-, bzw. Kostenstellennummern und Erlöskonten ein. Anbei die Liste der unterschiedlichen GWL Typen und dem entsprechenden ktr_typ Code:
@@ -117,5 +118,5 @@ Anhand der Angabe «ktr_typ» wird ein Kostenträger einer ITAR_K-Spalte zugeord
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Um ein ITAR_K ausfüllen zu können, werden die Kosten der ambulanten Fälle summarisch pro KTR Typ (z.B. Tarif Dialyse) abgefüllt.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -6,7 +6,8 @@ weight: 50
 type: docs
 keywords: []
 ---
- 
+
+{{<faqBlock>}} 
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 1. Aus SDEP ist mir die Abgrenzungsrechnung bekannt. Wird es diese in SpiGes auch geben oder nur gemäss ITAR_K?
@@ -64,3 +65,5 @@ Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenart
 - 448 Kalkulatorische Verzinsung des Anlagevermögens <br />
 Weitere Informationen sind im REKOLE®-Handbuch (Kapitel 6.5.3) zu finden.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -33,7 +33,7 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
 {{</listItem>}}
 
 {{<listItem>}}
-Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
+Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 -	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. 

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -26,9 +26,7 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
 
 4. Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-
 -	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. 
-
 -	Zusammengefasst sind die Anlagenutzungskosten nach folgenden Methoden abzubilden:
 <table class="w-100">
   <tr>
@@ -56,8 +54,6 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
     <td> REKOLE </td>
   </tr>
 </table>
-
-
 {{</collapsibleBlock>}}
 
 5. Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}} 
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
+{{<numberedList>}}
 1. Aus SDEP ist mir die Abgrenzungsrechnung bekannt. Wird es diese in SpiGes auch geben oder nur gemäss ITAR_K?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes nutzt die Abstimmbrücke der GDK / von REKOLE.
@@ -69,5 +70,5 @@ Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenart
 Weitere Informationen sind im REKOLE®-Handbuch (Kapitel 6.5.3) zu finden.
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<faqBlock>}} 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 {{<numberedList>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -26,10 +26,10 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
 
 4. Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-<ul>
-<li>	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. </li>
 
-<li>	Zusammengefasst sind die Anlagenutzungskosten nach folgenden Methoden abzubilden:
+-	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. 
+
+-	Zusammengefasst sind die Anlagenutzungskosten nach folgenden Methoden abzubilden:
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variablen </div></th>
@@ -56,8 +56,8 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
     <td> REKOLE </td>
   </tr>
 </table>
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 5. Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -26,7 +26,7 @@ Die Begründungen werden als Prüfungen in SpiGes erfasst. D.h. wenn ein Betrag 
 {{</listItem>}}
 
 {{<listItem>}}
-Wo werden die Kosten der Überlieger in der Abstimmungsbrücke berücksichtigt? 
+Wo werden die Kosten der Überlieger in der Abstimmungsbrücke berücksichtigt?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr ausgetretenen Patienten (A Fälle) berechnen. Diese können bereits im Vorjahr ins Spital eingetreten sein und Kosten verursacht haben. In der Finanzbuchhaltung wird der Aufwand pro Jahr (Zeitrechnung) eingegeben. Die daraus entstehende Differenz wird in der Abstimmungsbrücke von SpiGes korrigiert.
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -11,22 +11,29 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 {{<numberedList>}}
-1. Aus SDEP ist mir die Abgrenzungsrechnung bekannt. Wird es diese in SpiGes auch geben oder nur gemäss ITAR_K?
+{{<listItem>}}
+Aus SDEP ist mir die Abgrenzungsrechnung bekannt. Wird es diese in SpiGes auch geben oder nur gemäss ITAR_K?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes nutzt die Abstimmbrücke der GDK / von REKOLE.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wo im BFS werden die Begründungen zu den Abgrenzungen integriert? Bzw wie muss ich mir das vorstellen?
+{{<listItem>}}
+Wo im BFS werden die Begründungen zu den Abgrenzungen integriert? Bzw wie muss ich mir das vorstellen?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Die Begründungen werden als Prüfungen in SpiGes erfasst. D.h. wenn ein Betrag von FiBu und BeBu nicht übereinstimmt, muss die Differenz begründet werden. Diese Begründungen werden dann auch weiterverwendet, z.B. für das Prüfprotokoll und für ITAR_K oder auch für die GDK Abstimmbrücke.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Wo werden die Kosten der Überlieger in der Abstimmungsbrücke berücksichtigt? 
+{{<listItem>}}
+Wo werden die Kosten der Überlieger in der Abstimmungsbrücke berücksichtigt? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr ausgetretenen Patienten (A Fälle) berechnen. Diese können bereits im Vorjahr ins Spital eingetreten sein und Kosten verursacht haben. In der Finanzbuchhaltung wird der Aufwand pro Jahr (Zeitrechnung) eingegeben. Die daraus entstehende Differenz wird in der Abstimmungsbrücke von SpiGes korrigiert.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
+{{<listItem>}}
+Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 -	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. 
@@ -59,8 +66,10 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?
+{{<listItem>}}
+ Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenarten:      
@@ -70,5 +79,7 @@ Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenart
 Weitere Informationen sind im REKOLE®-Handbuch (Kapitel 6.5.3) zu finden.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -6,7 +6,7 @@ weight: 50
 type: docs
 keywords: []
 ---
-
+ 
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 1. Aus SDEP ist mir die Abgrenzungsrechnung bekannt. Wird es diese in SpiGes auch geben oder nur gemäss ITAR_K?

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -27,8 +27,10 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
 
 4. Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten der Fälle nach VKL angefordert. In SpiGes ermöglichen es die Variablen "_ank", die Details der Anlagenutzungskosten der Fälle nach REKOLE zu senden. Da dieses Detail nun für SwissDRG AG benötigt wird, sollte man in SpiGes die "_ank"-Variablen nicht auch für die VKL-Ergebnisse vorsehen? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
+{{<markdown>}}
 -	Es handelt sich hierbei lediglich um eine Testerhebung der SwissDRG AG. Sollte der definitive Wechsel zu VKL erfolgen, würden die Anlagenutzungskosten pro Kostenstelle in SpiGes nach VKL statt nach REKOLE erhoben werden und die REKOLE-Anlagenutzungskosten als Summe. 
 -	Zusammengefasst sind die Anlagenutzungskosten nach folgenden Methoden abzubilden:
+{{</markdown>}}
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variablen </div></th>
@@ -59,11 +61,13 @@ In der Kostenträgerrechnung von SpiGes lassen sich die Kosten der übers Jahr a
 
 5. Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenarten: <br />
-- 442 Abschreibungen <br />
-- 444 Übrige Mietzinse (inkl. operatives Leasing) <br />
-- 448 Kalkulatorische Verzinsung des Anlagevermögens <br />
+{{<markdown>}}
+Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenarten:      
+- 442 Abschreibungen      
+- 444 Übrige Mietzinse (inkl. operatives Leasing)       
+- 448 Kalkulatorische Verzinsung des Anlagevermögens      
 Weitere Informationen sind im REKOLE®-Handbuch (Kapitel 6.5.3) zu finden.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/de/FAQ/5_abstimmungsbrucke.md
+++ b/content/de/FAQ/5_abstimmungsbrucke.md
@@ -72,10 +72,11 @@ Für 2024 (Daten 2023) hat die SwissDRG AG die Details der Anlagenutzungskosten 
  Das Konto 441 wird weder von VKL noch von REKOLE in die Berechnung der Anlagenutzungskosten einbezogen. Können Sie das bestätigen?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
-Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenarten:      
-- 442 Abschreibungen      
-- 444 Übrige Mietzinse (inkl. operatives Leasing)       
-- 448 Kalkulatorische Verzinsung des Anlagevermögens      
+Die Anlagenutzungskosten (nach REKOLE® und OCP) entsprechen folgenden Kostenarten:
+
+- 442 Abschreibungen
+- 444 Übrige Mietzinse (inkl. operatives Leasing)
+- 448 Kalkulatorische Verzinsung des Anlagevermögens
 Weitere Informationen sind im REKOLE®-Handbuch (Kapitel 6.5.3) zu finden.
 {{</markdown>}}
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -93,8 +93,10 @@ Es wird mehrere Exportfiles geben. Einerseits wird man das XML-File, was die Spi
 
 7. Spielt im XML-Format die Reihenfolge der Variablen innerhalb einer Zeile eine Rolle?
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - Die Reihenfolge der Elemente ist vorgegeben und nicht veränderbar. Elemente können höchstens weggelassen werden. Also für das Fall-Element sind die Unterelemente immer in der Reihenfolge «Administratives», «Neugeborene», «Psychiatrie», «KostenträgerFall», «Diagnose», «Behandlung», «Medikament», «Rechnung», «Patientenbewegung» und «Kantonsdaten» anzugeben. 
 - Die Reihenfolge der Attribute ist hingegen frei wählbar. So kann z.B. im Element «Administratives» sowohl «…geschlecht="2" alter="37"…» als auch «…alter="37" geschlecht="2"…» angegeben werden. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 8. Können auch Variablen innerhalb einer Zeile fehlen, falls die Klinik in dieser Zeile nichts zu der entsprechenden Variable auszufüllen hat? Oder müssen immer alle Variablen der Schnittstelle in jeder Zeile stehen?
@@ -114,10 +116,12 @@ Es wird ein Prüftool via API (Application Programming Interfaces) zur Verfügun
 
 11. Ist schon bekannt, wie das Vorgehen in Bezug auf die kantonalen Zusatzdaten sein wird? Verschiedene Kantone (z.B. LU, GR, VS und VD) haben ja bereits heute eine MK-Zeile. Zudem erheben die Kantone ZH und BE im Rahmen von SDEP ebenfalls zusätzliche Daten. Wissen Sie bereits, ob diese Daten in den Export SpiGes integriert werden oder ob diese separat exportiert werden müssen?
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - Die kantonalen Zusatzdaten wurden in der Schnittstelle berücksichtigt; siehe Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform 1.3:
-Stationäre Spitalaufenthalte: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html"> Mehrfachnutzung der Daten (Projekt SpiGes) </a> 
+Stationäre Spitalaufenthalte: [Mehrfachnutzung der Daten (Projekt SpiGes)](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html). 
 - Die kantonalen Zusatzdaten können zwar im XML angegeben werden, werden beim Import auf die SpiGes Plattform jedoch nicht weiterverarbeitet. Sie werden von den Kantonen separat plausibilisiert und bearbeitet. 
 - Exportierbar sind die Kantonsdaten nur durch das Spital selbst und durch den Kanton. Voraussichtlich sind die Kantonsdaten für diese User im selben XML-File enthalten, wie die restlichen Daten. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 12. Wird es möglich sein, Korrekturen direkt auf der Plattform vorzunehmen?
@@ -132,8 +136,10 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 
 14. Neue Variablen medi_id und rech_id: Aus der Beschreibung sind wir uns nicht sicher, ob hier laufende Nummern oder tatsächliche ID aus dem System gemeint sind. Wenn ja, welche? Bei der medi_id dachten wir sofort an den ATC_Code, jedoch gibt es hierfür eine extra Variable.
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - Es handelt sich bei de beiden neuen Variablen «medi_id» und «rech_id» um Identifikatoren, die zur eindeutigen Zuordnung aus technischen Gründen nötig. Diese müssen nicht zwingend mit 1 beginnen, sie müssen aber für jeden Fall eindeutig sein. 
 - In der XML-Musterdatei 1.3, welche Sie auf unserer Homepage vorfinden, ist auch ein Beispiel enthalten. medi_id="1" enthält die Information, dass es sich um das erste hochteure Medikament gemäss den Vorgaben der SwissDRG AG für diesen spezifischen Fall handelt. 
+{{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
 

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -92,10 +92,8 @@ Es wird mehrere Exportfiles geben. Einerseits wird man das XML-File, was die Spi
 
 7. Spielt im XML-Format die Reihenfolge der Variablen innerhalb einer Zeile eine Rolle?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - Die Reihenfolge der Elemente ist vorgegeben und nicht veränderbar. Elemente können höchstens weggelassen werden. Also für das Fall-Element sind die Unterelemente immer in der Reihenfolge «Administratives», «Neugeborene», «Psychiatrie», «KostenträgerFall», «Diagnose», «Behandlung», «Medikament», «Rechnung», «Patientenbewegung» und «Kantonsdaten» anzugeben. 
 - Die Reihenfolge der Attribute ist hingegen frei wählbar. So kann z.B. im Element «Administratives» sowohl «…geschlecht="2" alter="37"…» als auch «…alter="37" geschlecht="2"…» angegeben werden. 
-
 {{</collapsibleBlock>}}
 
 8. Können auch Variablen innerhalb einer Zeile fehlen, falls die Klinik in dieser Zeile nichts zu der entsprechenden Variable auszufüllen hat? Oder müssen immer alle Variablen der Schnittstelle in jeder Zeile stehen?
@@ -115,12 +113,10 @@ Es wird ein Prüftool via API (Application Programming Interfaces) zur Verfügun
 
 11. Ist schon bekannt, wie das Vorgehen in Bezug auf die kantonalen Zusatzdaten sein wird? Verschiedene Kantone (z.B. LU, GR, VS und VD) haben ja bereits heute eine MK-Zeile. Zudem erheben die Kantone ZH und BE im Rahmen von SDEP ebenfalls zusätzliche Daten. Wissen Sie bereits, ob diese Daten in den Export SpiGes integriert werden oder ob diese separat exportiert werden müssen?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - Die kantonalen Zusatzdaten wurden in der Schnittstelle berücksichtigt; siehe Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform 1.3:
 Stationäre Spitalaufenthalte: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html"> Mehrfachnutzung der Daten (Projekt SpiGes) </a> 
 - Die kantonalen Zusatzdaten können zwar im XML angegeben werden, werden beim Import auf die SpiGes Plattform jedoch nicht weiterverarbeitet. Sie werden von den Kantonen separat plausibilisiert und bearbeitet. 
 - Exportierbar sind die Kantonsdaten nur durch das Spital selbst und durch den Kanton. Voraussichtlich sind die Kantonsdaten für diese User im selben XML-File enthalten, wie die restlichen Daten. 
- 
 {{</collapsibleBlock>}}
 
 12. Wird es möglich sein, Korrekturen direkt auf der Plattform vorzunehmen?
@@ -135,12 +131,9 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 
 14. Neue Variablen medi_id und rech_id: Aus der Beschreibung sind wir uns nicht sicher, ob hier laufende Nummern oder tatsächliche ID aus dem System gemeint sind. Wenn ja, welche? Bei der medi_id dachten wir sofort an den ATC_Code, jedoch gibt es hierfür eine extra Variable.
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - Es handelt sich bei de beiden neuen Variablen «medi_id» und «rech_id» um Identifikatoren, die zur eindeutigen Zuordnung aus technischen Gründen nötig. Diese müssen nicht zwingend mit 1 beginnen, sie müssen aber für jeden Fall eindeutig sein. 
 - In der XML-Musterdatei 1.3, welche Sie auf unserer Homepage vorfinden, ist auch ein Beispiel enthalten. medi_id="1" enthält die Information, dass es sich um das erste hochteure Medikament gemäss den Vorgaben der SwissDRG AG für diesen spezifischen Fall handelt. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-
-
 {{</collapsibleBlock>}}
 
 15. In den Beispieldateien für das Identifikatoren-File und das Daten-File gibt es zwei Felder für die Version. Diese Versionen stimmen aber nicht überein. So wird im Header die Version 1.0 angegeben und beim Tag Unternehmen die Version 1.3. Warum sind die Versionsnummern unterschiedlich? Woher wissen wir wann welche Versionsnummer anzugeben ist?

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -11,17 +11,22 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 {{<numberedList>}}
-1. Gibt es für den Datenimport in die SpiGes Applikation eine Formatvorlage?
+{{<listItem>}}
+Gibt es für den Datenimport in die SpiGes Applikation eine Formatvorlage?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Ja, die Formate im Schnittstellenkonzept sind zu übernehmen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wurden die grossen Anbieter von Pat.-Admin-Software (SAP) ebenfalls vom BFS informiert und entwickeln sie bereits Software-Lösungen? Vermutlich sollte das XML-File künftig in der Pat.-Admin-Software erstellt werden.
+{{<listItem>}}
+Wurden die grossen Anbieter von Pat.-Admin-Software (SAP) ebenfalls vom BFS informiert und entwickeln sie bereits Software-Lösungen? Vermutlich sollte das XML-File künftig in der Pat.-Admin-Software erstellt werden.
 {{<collapsibleBlock groupId="technische_fragen">}}
 Im Januar 2023 haben wir ein Informationsveranstaltung Richtung KIS Hersteller (Pat.-Admin-Software) gemacht. SAP war auch repräsentiert. Das BFS informiert diese Gruppe laufend über den Stand von SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Gemäss Variablenliste 1.3 gibt es folgende Tabellen:
+{{<listItem>}}
+Gemäss Variablenliste 1.3 gibt es folgende Tabellen:
 <table>
   <tr>
     <td> 1 </td>
@@ -76,46 +81,62 @@ Kann man unter SpiGes diese Tabellen alle als einzelnes xml-File abgeben?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Die Tabelle 12 Personenidentifikatoren muss in einem separaten File geliefert werden (aus Datenschutzgründen). Für die restlichen Tabellen ist ein anderes File definiert, welches aber Teillieferungen unterstützt. Theoretisch ist es also möglich, alle Tabellen in einem einzelnen XML-File als Teillieferungen zu liefern. Wir empfehlen dies jedoch nicht, da dies eine aufwändige Abstimmung der verschiedenen Tabellen erfordert (Sicherstellen, dass die Informationen zu allen Fällen in allen Files vorhanden sind).  Genauere Informationen zu diesem Thema finden Sie in der Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform auf unserer Webseite <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html </a>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Gibt es eine Möglichkeit für kleine Betriebe aus einem Excel (in der die KTR eingetragen ist) ein XML-File herzustellen. Gibt es ein Anbieter, der dies plant umzusetzen?
+{{<listItem>}}
+Gibt es eine Möglichkeit für kleine Betriebe aus einem Excel (in der die KTR eingetragen ist) ein XML-File herzustellen. Gibt es ein Anbieter, der dies plant umzusetzen?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Diese Möglichkeit wird zurzeit vom BFS geprüft.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Ist geplant eine Excel für die fallunabhängigen Kosten zur Verfügung zu stellen, in welchem der Betrieb die fallunabhängigen Kosten im Excel-Format ausfüllen kann und dann als XML-Format exportieren kann? 
+{{<listItem>}}
+Ist geplant eine Excel für die fallunabhängigen Kosten zur Verfügung zu stellen, in welchem der Betrieb die fallunabhängigen Kosten im Excel-Format ausfüllen kann und dann als XML-Format exportieren kann? 
 {{<collapsibleBlock groupId="technische_fragen">}}
 Die separate Lieferung von verschiedenen Arten von XML-Elementen ist möglich. D.h. die fallunabhängigen Kostenträger können grundsätzlich in einem anderen File als die fallabhängigen Kostenträger geliefert werden. Ob wir ein Tool für die Transformation der Daten aus einem Excel-File bereitstellen können, müssen wir noch abklären.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Hat das SpiGes Exportfile die gleiche Struktur wie das File, welches die Spitäler in SpiGes importieren?
+{{<listItem>}}
+Hat das SpiGes Exportfile die gleiche Struktur wie das File, welches die Spitäler in SpiGes importieren?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Es wird mehrere Exportfiles geben. Einerseits wird man das XML-File, was die Spitäler importieren, auch exportieren können und andererseits wird ein Export in einem flachen Format (mehrere CSV-Dateien) möglich sein.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Spielt im XML-Format die Reihenfolge der Variablen innerhalb einer Zeile eine Rolle?
+{{<listItem>}}
+Spielt im XML-Format die Reihenfolge der Variablen innerhalb einer Zeile eine Rolle?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Die Reihenfolge der Elemente ist vorgegeben und nicht veränderbar. Elemente können höchstens weggelassen werden. Also für das Fall-Element sind die Unterelemente immer in der Reihenfolge «Administratives», «Neugeborene», «Psychiatrie», «KostenträgerFall», «Diagnose», «Behandlung», «Medikament», «Rechnung», «Patientenbewegung» und «Kantonsdaten» anzugeben. 
 - Die Reihenfolge der Attribute ist hingegen frei wählbar. So kann z.B. im Element «Administratives» sowohl «…geschlecht="2" alter="37"…» als auch «…alter="37" geschlecht="2"…» angegeben werden. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. Können auch Variablen innerhalb einer Zeile fehlen, falls die Klinik in dieser Zeile nichts zu der entsprechenden Variable auszufüllen hat? Oder müssen immer alle Variablen der Schnittstelle in jeder Zeile stehen?
+{{<listItem>}}
+Können auch Variablen innerhalb einer Zeile fehlen, falls die Klinik in dieser Zeile nichts zu der entsprechenden Variable auszufüllen hat? Oder müssen immer alle Variablen der Schnittstelle in jeder Zeile stehen?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Ja, Variablen können fehlen. Gewisse Variablen müssen aber zwingend angegeben werden. Diese sind im XSD-Definitionsfile als «required» gekennzeichnet («xs:attribute name="fall_id" use="required"»). In der Variablenliste werden wir diese Information auch noch ergänzen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-9. Können die Variablen, welche keinen Inhalt haben, auch mit einem NULLWERT geliefert werden (zum Beispiel vollständige KTR-Zeilen mit NULLEN in den Variablen wo nichts vorhanden ist)? 
+{{<listItem>}}
+Können die Variablen, welche keinen Inhalt haben, auch mit einem NULLWERT geliefert werden (zum Beispiel vollständige KTR-Zeilen mit NULLEN in den Variablen wo nichts vorhanden ist)? 
 {{<collapsibleBlock groupId="technische_fragen">}}
 Das kommt auf die Variablen an. Bei den KTR-Variablen ist es möglich, alle Variablen mit dem Wert «0» zu erfassen. Leere Variablen («») oder Nullwerte («NULL») sind jedoch nicht zulässig. Falls Sie das konkret überprüfen möchten, können Sie ihr XML-File gegen die XSD-Definition validieren. Dazu gibt es online gratis Tools. Bitte beachten Sie dabei, dass keine echten Daten auf solche Plattformen hochgeladen werden dürfen. Fiktive Beispiel-Files können sie aber so überprüfen. Auch die SpiGes Plattform wird eine solche Validierung bereitstellen. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10. Wird es eine Plausibilisierungssoftware analog Medplaus geben, die vor dem Upload lokal innerhalb der Spitäler eingesetzt werden kann?
+{{<listItem>}}
+Wird es eine Plausibilisierungssoftware analog Medplaus geben, die vor dem Upload lokal innerhalb der Spitäler eingesetzt werden kann?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Es wird ein Prüftool via API (Application Programming Interfaces) zur Verfügung gestellt werden. Dies wird jedoch erst im Laufe des kommenden Jahres bereitstehen. Bis dahin empfehlen wir MedPlaus weiter zu verwenden. Davon wird es auch eine Version für das Jahr 2024 geben.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-11. Ist schon bekannt, wie das Vorgehen in Bezug auf die kantonalen Zusatzdaten sein wird? Verschiedene Kantone (z.B. LU, GR, VS und VD) haben ja bereits heute eine MK-Zeile. Zudem erheben die Kantone ZH und BE im Rahmen von SDEP ebenfalls zusätzliche Daten. Wissen Sie bereits, ob diese Daten in den Export SpiGes integriert werden oder ob diese separat exportiert werden müssen?
+{{<listItem>}}
+Ist schon bekannt, wie das Vorgehen in Bezug auf die kantonalen Zusatzdaten sein wird? Verschiedene Kantone (z.B. LU, GR, VS und VD) haben ja bereits heute eine MK-Zeile. Zudem erheben die Kantone ZH und BE im Rahmen von SDEP ebenfalls zusätzliche Daten. Wissen Sie bereits, ob diese Daten in den Export SpiGes integriert werden oder ob diese separat exportiert werden müssen?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Die kantonalen Zusatzdaten wurden in der Schnittstelle berücksichtigt; siehe Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform 1.3:
@@ -124,18 +145,24 @@ Stationäre Spitalaufenthalte: [Mehrfachnutzung der Daten (Projekt SpiGes)](http
 - Exportierbar sind die Kantonsdaten nur durch das Spital selbst und durch den Kanton. Voraussichtlich sind die Kantonsdaten für diese User im selben XML-File enthalten, wie die restlichen Daten. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-12. Wird es möglich sein, Korrekturen direkt auf der Plattform vorzunehmen?
+{{<listItem>}}
+Wird es möglich sein, Korrekturen direkt auf der Plattform vorzunehmen?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Nein, die Plattform bietet keine Möglichkeit, Daten einzugeben oder zu korrigieren. Ziel ist es, die Fehler an der Quelle, d.h. in den Systemen der Krankenhäuser, zu korrigieren, damit die späteren Exporte konsistent sind und die Fehler in den nächsten Erhebungen nicht mehr auftauchen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-13. Neue Formate: Es gibt neue Formate. Beispielweise bei rech_betrag. Das Format lautet N10.2 Wir vermuten, es handelt sich hierbei um die Angabe von Dezimalstellen. In diesem Fall 2 Dezimalstellen und eine Gesamtlänge von 12. Ist dies korrekt?
+{{<listItem>}}
+Neue Formate: Es gibt neue Formate. Beispielweise bei rech_betrag. Das Format lautet N10.2 Wir vermuten, es handelt sich hierbei um die Angabe von Dezimalstellen. In diesem Fall 2 Dezimalstellen und eine Gesamtlänge von 12. Ist dies korrekt?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkommastellen (und ergo max. 8 Vorkommastellen).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-14. Neue Variablen medi_id und rech_id: Aus der Beschreibung sind wir uns nicht sicher, ob hier laufende Nummern oder tatsächliche ID aus dem System gemeint sind. Wenn ja, welche? Bei der medi_id dachten wir sofort an den ATC_Code, jedoch gibt es hierfür eine extra Variable.
+{{<listItem>}}
+Neue Variablen medi_id und rech_id: Aus der Beschreibung sind wir uns nicht sicher, ob hier laufende Nummern oder tatsächliche ID aus dem System gemeint sind. Wenn ja, welche? Bei der medi_id dachten wir sofort an den ATC_Code, jedoch gibt es hierfür eine extra Variable.
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Es handelt sich bei de beiden neuen Variablen «medi_id» und «rech_id» um Identifikatoren, die zur eindeutigen Zuordnung aus technischen Gründen nötig. Diese müssen nicht zwingend mit 1 beginnen, sie müssen aber für jeden Fall eindeutig sein. 
@@ -143,11 +170,15 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 {{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-15. In den Beispieldateien für das Identifikatoren-File und das Daten-File gibt es zwei Felder für die Version. Diese Versionen stimmen aber nicht überein. So wird im Header die Version 1.0 angegeben und beim Tag Unternehmen die Version 1.3. Warum sind die Versionsnummern unterschiedlich? Woher wissen wir wann welche Versionsnummer anzugeben ist?
+{{<listItem>}}
+In den Beispieldateien für das Identifikatoren-File und das Daten-File gibt es zwei Felder für die Version. Diese Versionen stimmen aber nicht überein. So wird im Header die Version 1.0 angegeben und beim Tag Unternehmen die Version 1.3. Warum sind die Versionsnummern unterschiedlich? Woher wissen wir wann welche Versionsnummer anzugeben ist?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 «?xml version=“1.0″» steht immer so. Die oberste Version bezieht sich also auf das «XML» selbst, und die untere auf das spezifische SpiGes XML.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
+{{<numberedList>}}
 1. Gibt es für den Datenimport in die SpiGes Applikation eine Formatvorlage?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Ja, die Formate im Schnittstellenkonzept sind zu übernehmen.
@@ -148,5 +149,5 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 «?xml version=“1.0″» steht immer so. Die oberste Version bezieht sich also auf das «XML» selbst, und die untere auf das spezifische SpiGes XML.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 1. Gibt es für den Datenimport in die SpiGes Applikation eine Formatvorlage?
@@ -141,3 +142,5 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 «?xml version=“1.0″» steht immer so. Die oberste Version bezieht sich also auf das «XML» selbst, und die untere auf das spezifische SpiGes XML.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -124,7 +124,7 @@ Ja, Variablen können fehlen. Gewisse Variablen müssen aber zwingend angegeben 
 {{<listItem>}}
 Können die Variablen, welche keinen Inhalt haben, auch mit einem NULLWERT geliefert werden (zum Beispiel vollständige KTR-Zeilen mit NULLEN in den Variablen wo nichts vorhanden ist)? 
 {{<collapsibleBlock groupId="technische_fragen">}}
-Das kommt auf die Variablen an. Bei den KTR-Variablen ist es möglich, alle Variablen mit dem Wert «0» zu erfassen. Leere Variablen («») oder Nullwerte («NULL») sind jedoch nicht zulässig. Falls Sie das konkret überprüfen möchten, können Sie ihr XML-File gegen die XSD-Definition validieren. Dazu gibt es online gratis Tools. Bitte beachten Sie dabei, dass keine echten Daten auf solche Plattformen hochgeladen werden dürfen. Fiktive Beispiel-Files können sie aber so überprüfen. Auch die SpiGes Plattform wird eine solche Validierung bereitstellen. 
+Das kommt auf die Variablen an. Bei den KTR-Variablen ist es möglich, alle Variablen mit dem Wert «0» zu erfassen. Leere Variablen («») oder Nullwerte («NULL») sind jedoch nicht zulässig. Falls Sie das konkret überprüfen möchten, können Sie ihr XML-File gegen die XSD-Definition validieren. Dazu gibt es online gratis Tools. Bitte beachten Sie dabei, dass keine echten Daten auf solche Plattformen hochgeladen werden dürfen. Fiktive Beispiel-Files können sie aber so überprüfen. Auch die SpiGes Plattform wird eine solche Validierung bereitstellen.
 {{</collapsibleBlock>}}
 {{</listItem>}}
 

--- a/content/de/FAQ/6_technische_fragen.md
+++ b/content/de/FAQ/6_technische_fragen.md
@@ -92,10 +92,10 @@ Es wird mehrere Exportfiles geben. Einerseits wird man das XML-File, was die Spi
 
 7. Spielt im XML-Format die Reihenfolge der Variablen innerhalb einer Zeile eine Rolle?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Die Reihenfolge der Elemente ist vorgegeben und nicht veränderbar. Elemente können höchstens weggelassen werden. Also für das Fall-Element sind die Unterelemente immer in der Reihenfolge «Administratives», «Neugeborene», «Psychiatrie», «KostenträgerFall», «Diagnose», «Behandlung», «Medikament», «Rechnung», «Patientenbewegung» und «Kantonsdaten» anzugeben. </li>
-<li> Die Reihenfolge der Attribute ist hingegen frei wählbar. So kann z.B. im Element «Administratives» sowohl «…geschlecht="2" alter="37"…» als auch «…alter="37" geschlecht="2"…» angegeben werden. </li>
-</ul>
+
+- Die Reihenfolge der Elemente ist vorgegeben und nicht veränderbar. Elemente können höchstens weggelassen werden. Also für das Fall-Element sind die Unterelemente immer in der Reihenfolge «Administratives», «Neugeborene», «Psychiatrie», «KostenträgerFall», «Diagnose», «Behandlung», «Medikament», «Rechnung», «Patientenbewegung» und «Kantonsdaten» anzugeben. 
+- Die Reihenfolge der Attribute ist hingegen frei wählbar. So kann z.B. im Element «Administratives» sowohl «…geschlecht="2" alter="37"…» als auch «…alter="37" geschlecht="2"…» angegeben werden. 
+
 {{</collapsibleBlock>}}
 
 8. Können auch Variablen innerhalb einer Zeile fehlen, falls die Klinik in dieser Zeile nichts zu der entsprechenden Variable auszufüllen hat? Oder müssen immer alle Variablen der Schnittstelle in jeder Zeile stehen?
@@ -115,12 +115,12 @@ Es wird ein Prüftool via API (Application Programming Interfaces) zur Verfügun
 
 11. Ist schon bekannt, wie das Vorgehen in Bezug auf die kantonalen Zusatzdaten sein wird? Verschiedene Kantone (z.B. LU, GR, VS und VD) haben ja bereits heute eine MK-Zeile. Zudem erheben die Kantone ZH und BE im Rahmen von SDEP ebenfalls zusätzliche Daten. Wissen Sie bereits, ob diese Daten in den Export SpiGes integriert werden oder ob diese separat exportiert werden müssen?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Die kantonalen Zusatzdaten wurden in der Schnittstelle berücksichtigt; siehe Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform 1.3:
-Stationäre Spitalaufenthalte: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html"> Mehrfachnutzung der Daten (Projekt SpiGes) </a> </li>
-<li> Die kantonalen Zusatzdaten können zwar im XML angegeben werden, werden beim Import auf die SpiGes Plattform jedoch nicht weiterverarbeitet. Sie werden von den Kantonen separat plausibilisiert und bearbeitet. </li>
-<li> Exportierbar sind die Kantonsdaten nur durch das Spital selbst und durch den Kanton. Voraussichtlich sind die Kantonsdaten für diese User im selben XML-File enthalten, wie die restlichen Daten. </li>
-</ul> 
+
+- Die kantonalen Zusatzdaten wurden in der Schnittstelle berücksichtigt; siehe Beschreibung der XML-Datei für den Datenimport in die SpiGes-Plattform 1.3:
+Stationäre Spitalaufenthalte: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.html"> Mehrfachnutzung der Daten (Projekt SpiGes) </a> 
+- Die kantonalen Zusatzdaten können zwar im XML angegeben werden, werden beim Import auf die SpiGes Plattform jedoch nicht weiterverarbeitet. Sie werden von den Kantonen separat plausibilisiert und bearbeitet. 
+- Exportierbar sind die Kantonsdaten nur durch das Spital selbst und durch den Kanton. Voraussichtlich sind die Kantonsdaten für diese User im selben XML-File enthalten, wie die restlichen Daten. 
+ 
 {{</collapsibleBlock>}}
 
 12. Wird es möglich sein, Korrekturen direkt auf der Plattform vorzunehmen?
@@ -135,12 +135,12 @@ Nicht ganz. N10.2 bezeichnet eine Zahl mit insgesamt 10 Stellen, davon 2 Nachkom
 
 14. Neue Variablen medi_id und rech_id: Aus der Beschreibung sind wir uns nicht sicher, ob hier laufende Nummern oder tatsächliche ID aus dem System gemeint sind. Wenn ja, welche? Bei der medi_id dachten wir sofort an den ATC_Code, jedoch gibt es hierfür eine extra Variable.
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Es handelt sich bei de beiden neuen Variablen «medi_id» und «rech_id» um Identifikatoren, die zur eindeutigen Zuordnung aus technischen Gründen nötig. Diese müssen nicht zwingend mit 1 beginnen, sie müssen aber für jeden Fall eindeutig sein. </li>
-<li> In der XML-Musterdatei 1.3, welche Sie auf unserer Homepage vorfinden, ist auch ein Beispiel enthalten. medi_id="1" enthält die Information, dass es sich um das erste hochteure Medikament gemäss den Vorgaben der SwissDRG AG für diesen spezifischen Fall handelt. 
+
+- Es handelt sich bei de beiden neuen Variablen «medi_id» und «rech_id» um Identifikatoren, die zur eindeutigen Zuordnung aus technischen Gründen nötig. Diese müssen nicht zwingend mit 1 beginnen, sie müssen aber für jeden Fall eindeutig sein. 
+- In der XML-Musterdatei 1.3, welche Sie auf unserer Homepage vorfinden, ist auch ein Beispiel enthalten. medi_id="1" enthält die Information, dass es sich um das erste hochteure Medikament gemäss den Vorgaben der SwissDRG AG für diesen spezifischen Fall handelt. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 15. In den Beispieldateien für das Identifikatoren-File und das Daten-File gibt es zwei Felder für die Version. Diese Versionen stimmen aber nicht überein. So wird im Header die Version 1.0 angegeben und beim Tag Unternehmen die Version 1.3. Warum sind die Versionsnummern unterschiedlich? Woher wissen wir wann welche Versionsnummer anzugeben ist?

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -17,8 +17,10 @@ Die Fallzusammenführung wird in SpiGes gemäss den Richtlinien der SwissDRG AG 
 
 2. fall_id_ch: Wer generiert diese Fallnummer und wird diese automatisch in Opale (IRP-System) hinterlegt? Bisher konnten wir die Fallidentifikation in beiden Dateien (BFS-Daten und Fallkostendatei) automatisch in Opale generieren.
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - Die schweizweit eindeutige Fallnummer wird durch die SpiGes-Plattform generiert. Bei einem Datenexport aus der Plattform steht diese fall_id_ch den Datennutzern zur Verfügung.
 - Der Identifikator des Falls, die Variable fall_id wird durch die Spitäler generiert. Die Spitalsoftware (wie z.B. Opale) sollte weiterhin über diese Funktion verfügen.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Es gibt Variablen (z.B. beatmung), wo im Zeitbezug «ganzer Fall» oder «Erhebungsjahr» steht. In den meisten Spitälern wird diese Position aber nicht auf der Zeitachse geführt, sondern einmalig auf dem Fall. Auch im bisherigen MS-Datensatz wurden solche Positionen immer nur für A-Fälle geliefert. Wie stellen Sie sich eine Lieferung von B/C-Fällen für diese Variablen vor?
@@ -28,8 +30,10 @@ Tatsächlich sind die Definitionen in diesem Aspekt vielleicht noch nicht für a
 
 4. Wie ist der «interne Übertritt» definiert?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 -	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv)
 -	oder für die sogenannten Wartepatienten/-patientinnen
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. Ist es möglich, eine Definition für den Wert «7 = Repatriierung» zu erhalten?
@@ -39,23 +43,29 @@ Rückführung eines Patienten oder einer Patientin mit Schweizer Hauptwohnsitz a
 
 6. Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 24 Std.» und «6 = Rückverlegung» der Variable Eintrittsart)
 {{<collapsibleBlock groupId="admninistratives">}}
--	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: <a href="https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf"> https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf </a>
+{{<markdown>}}
+-	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: [https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf](https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf)
 -	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 7. Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden:        
 austritt_aufenthalt: 2 = Krankenheim, Pflegeheim        
-eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb  
+eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ### Variable "Wohnland"
 
 8. In der Variablenbeschreibung ist eine separate Einteilung der aussereuropäischen Länder in Regionen erwähnt. Existiert diese Liste bereits oder wird sie noch veröffentlicht?
 {{<collapsibleBlock groupId="admninistratives">}}
-- Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a>
+{{<markdown>}}
+- Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html)
 -	Für die aussereuropäischen Länder können Regionen erfasst werden, es können aber auch die Ländercodes angegeben werden. Dies ist bereits in der MS so und hat sich nicht geändert. Das Format ist alphanumerisch und kann somit sowohl Zahlen wie Buchstaben enthalten.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ### Variable "versicherungsklasse"
@@ -67,7 +77,9 @@ Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missing
 
 10. Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit einer «Flex-Versicherung», die Information zu gewinnen und mit «8 = andere» zu hinterlegen. Gibt es bei den Auswertungen später ein Problem bzw. welche Auswirkungen ergeben sich auf die Statistik, wenn wir «8=andere» nicht angeben (können)?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 -	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
 -	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
 1. Werden im SpiGes-Datensatz die Fallklammer-Fälle (=zusammengeführter Fall) erwartet? ANQ erwartet im Bereich der Psychiatrie einen Datensatz mit den Einzelfällen, also nicht zusammengeführte Fälle. Gibt es bereits einen Austausch zwischen Ihnen und ANQ, bzgl. Nutzung des SpiGes-Datensatzes?
@@ -69,3 +70,4 @@ Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missing
 -	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
 -	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -11,46 +11,59 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="admninistratives">}}
 {{<numberedList>}}
 
-1. Werden im SpiGes-Datensatz die Fallklammer-Fälle (=zusammengeführter Fall) erwartet? ANQ erwartet im Bereich der Psychiatrie einen Datensatz mit den Einzelfällen, also nicht zusammengeführte Fälle. Gibt es bereits einen Austausch zwischen Ihnen und ANQ, bzgl. Nutzung des SpiGes-Datensatzes?
+{{<listItem>}}
+Werden im SpiGes-Datensatz die Fallklammer-Fälle (=zusammengeführter Fall) erwartet? ANQ erwartet im Bereich der Psychiatrie einen Datensatz mit den Einzelfällen, also nicht zusammengeführte Fälle. Gibt es bereits einen Austausch zwischen Ihnen und ANQ, bzgl. Nutzung des SpiGes-Datensatzes?
 {{<collapsibleBlock groupId="admninistratives">}}
 Die Fallzusammenführung wird in SpiGes gemäss den Richtlinien der SwissDRG AG gehandhabt. Wir sind mit dem ANQ im Austausch bezüglich der Handhabung der nicht zusammengeführten Fälle.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. fall_id_ch: Wer generiert diese Fallnummer und wird diese automatisch in Opale (IRP-System) hinterlegt? Bisher konnten wir die Fallidentifikation in beiden Dateien (BFS-Daten und Fallkostendatei) automatisch in Opale generieren.
+{{<listItem>}}
+fall_id_ch: Wer generiert diese Fallnummer und wird diese automatisch in Opale (IRP-System) hinterlegt? Bisher konnten wir die Fallidentifikation in beiden Dateien (BFS-Daten und Fallkostendatei) automatisch in Opale generieren.
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Die schweizweit eindeutige Fallnummer wird durch die SpiGes-Plattform generiert. Bei einem Datenexport aus der Plattform steht diese fall_id_ch den Datennutzern zur Verfügung.
 - Der Identifikator des Falls, die Variable fall_id wird durch die Spitäler generiert. Die Spitalsoftware (wie z.B. Opale) sollte weiterhin über diese Funktion verfügen.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Es gibt Variablen (z.B. beatmung), wo im Zeitbezug «ganzer Fall» oder «Erhebungsjahr» steht. In den meisten Spitälern wird diese Position aber nicht auf der Zeitachse geführt, sondern einmalig auf dem Fall. Auch im bisherigen MS-Datensatz wurden solche Positionen immer nur für A-Fälle geliefert. Wie stellen Sie sich eine Lieferung von B/C-Fällen für diese Variablen vor?
+{{<listItem>}}
+Es gibt Variablen (z.B. beatmung), wo im Zeitbezug «ganzer Fall» oder «Erhebungsjahr» steht. In den meisten Spitälern wird diese Position aber nicht auf der Zeitachse geführt, sondern einmalig auf dem Fall. Auch im bisherigen MS-Datensatz wurden solche Positionen immer nur für A-Fälle geliefert. Wie stellen Sie sich eine Lieferung von B/C-Fällen für diese Variablen vor?
 {{<collapsibleBlock groupId="admninistratives">}}
 Tatsächlich sind die Definitionen in diesem Aspekt vielleicht noch nicht für alle Variablen ganz detailscharf. Bis heute war es nicht festgelegt, ob diese Variablen für die B und C Fälle geliefert werden müssen. Grundsätzlich sollte es möglich sein, die Angaben zu liefern, nur so ist es mit den Daten möglich, Auslastungen zu berechnen. Allerdings dürfte es vielen Spitälern wie Ihnen gehen, dass Sie die Angaben für B und C-Fälle nicht haben. In diesem Fall können die Variablen für die B und C-Fälle leer gelassen werden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Wie ist der «interne Übertritt» definiert?
+{{<listItem>}}
+Wie ist der «interne Übertritt» definiert?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 -	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv)
 -	oder für die sogenannten Wartepatienten/-patientinnen
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Ist es möglich, eine Definition für den Wert «7 = Repatriierung» zu erhalten?
+{{<listItem>}}
+Ist es möglich, eine Definition für den Wert «7 = Repatriierung» zu erhalten?
 {{<collapsibleBlock groupId="admninistratives">}}
 Rückführung eines Patienten oder einer Patientin mit Schweizer Hauptwohnsitz aus dem Ausland in die Schweiz, ohne spezielle Anforderungen an Transportmittel oder Begleitung.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 24 Std.» und «6 = Rückverlegung» der Variable Eintrittsart)
+{{<listItem>}}
+Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 24 Std.» und «6 = Rückverlegung» der Variable Eintrittsart)
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 -	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: [https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf](https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf)
 -	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
+{{<listItem>}}
+Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden:        
@@ -58,30 +71,37 @@ austritt_aufenthalt: 2 = Krankenheim, Pflegeheim
 eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ### Variable "Wohnland"
 
-8. In der Variablenbeschreibung ist eine separate Einteilung der aussereuropäischen Länder in Regionen erwähnt. Existiert diese Liste bereits oder wird sie noch veröffentlicht?
+{{<listItem>}}
+In der Variablenbeschreibung ist eine separate Einteilung der aussereuropäischen Länder in Regionen erwähnt. Existiert diese Liste bereits oder wird sie noch veröffentlicht?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html)
 -	Für die aussereuropäischen Länder können Regionen erfasst werden, es können aber auch die Ländercodes angegeben werden. Dies ist bereits in der MS so und hat sich nicht geändert. Das Format ist alphanumerisch und kann somit sowohl Zahlen wie Buchstaben enthalten.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ### Variable "versicherungsklasse"
 
-9. Im Variablenbeschrieb steht, dass man es für alle angeben muss, ausser Selbstzahler. Im xsd. Ist das Feld jedoch «required». Was sollen wir dann bei Selbstzahlern liefern?
+{{<listItem>}}
+Im Variablenbeschrieb steht, dass man es für alle angeben muss, ausser Selbstzahler. Im xsd. Ist das Feld jedoch «required». Was sollen wir dann bei Selbstzahlern liefern?
 {{<collapsibleBlock groupId="admninistratives">}}
 Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missings vorhanden sind, wurde required vorausgesetzt. Dann betrifft es natürlich auch die Selbstzahler, welche mit 9=unbekannt codiert werden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10. Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit einer «Flex-Versicherung», die Information zu gewinnen und mit «8 = andere» zu hinterlegen. Gibt es bei den Auswertungen später ein Problem bzw. welche Auswirkungen ergeben sich auf die Statistik, wenn wir «8=andere» nicht angeben (können)?
+{{<listItem>}}
+Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit einer «Flex-Versicherung», die Information zu gewinnen und mit «8 = andere» zu hinterlegen. Gibt es bei den Auswertungen später ein Problem bzw. welche Auswirkungen ergeben sich auf die Statistik, wenn wir «8=andere» nicht angeben (können)?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 -	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
 -	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -16,10 +16,8 @@ Die Fallzusammenführung wird in SpiGes gemäss den Richtlinien der SwissDRG AG 
 
 2. fall_id_ch: Wer generiert diese Fallnummer und wird diese automatisch in Opale (IRP-System) hinterlegt? Bisher konnten wir die Fallidentifikation in beiden Dateien (BFS-Daten und Fallkostendatei) automatisch in Opale generieren.
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Die schweizweit eindeutige Fallnummer wird durch die SpiGes-Plattform generiert. Bei einem Datenexport aus der Plattform steht diese fall_id_ch den Datennutzern zur Verfügung. </li>
-<li> Der Identifikator des Falls, die Variable fall_id wird durch die Spitäler generiert. Die Spitalsoftware (wie z.B. Opale) sollte weiterhin über diese Funktion verfügen. </li>
-</ul>
+- Die schweizweit eindeutige Fallnummer wird durch die SpiGes-Plattform generiert. Bei einem Datenexport aus der Plattform steht diese fall_id_ch den Datennutzern zur Verfügung.
+- Der Identifikator des Falls, die Variable fall_id wird durch die Spitäler generiert. Die Spitalsoftware (wie z.B. Opale) sollte weiterhin über diese Funktion verfügen.
 {{</collapsibleBlock>}}
 
 3. Es gibt Variablen (z.B. beatmung), wo im Zeitbezug «ganzer Fall» oder «Erhebungsjahr» steht. In den meisten Spitälern wird diese Position aber nicht auf der Zeitachse geführt, sondern einmalig auf dem Fall. Auch im bisherigen MS-Datensatz wurden solche Positionen immer nur für A-Fälle geliefert. Wie stellen Sie sich eine Lieferung von B/C-Fällen für diese Variablen vor?
@@ -29,10 +27,8 @@ Tatsächlich sind die Definitionen in diesem Aspekt vielleicht noch nicht für a
 
 4. Wie ist der «interne Übertritt» definiert?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li>	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv) </li>
-<li>	oder für die sogenannten Wartepatienten/-patientinnen </li>
-</ul>
+-	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv)
+-	oder für die sogenannten Wartepatienten/-patientinnen
 {{</collapsibleBlock>}}
 
 5. Ist es möglich, eine Definition für den Wert «7 = Repatriierung» zu erhalten?
@@ -42,10 +38,8 @@ Rückführung eines Patienten oder einer Patientin mit Schweizer Hauptwohnsitz a
 
 6. Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 24 Std.» und «6 = Rückverlegung» der Variable Eintrittsart)
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li>	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: <a href="https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf"> https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf </a> </li>
-<li>	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital </li>
-</ul>
+-	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: <a href="https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf"> https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf </a>
+-	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital
 {{</collapsibleBlock>}}
 
 7. Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
@@ -59,10 +53,8 @@ eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb
 
 8. In der Variablenbeschreibung ist eine separate Einteilung der aussereuropäischen Länder in Regionen erwähnt. Existiert diese Liste bereits oder wird sie noch veröffentlicht?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a> </li>
-<li>	Für die aussereuropäischen Länder können Regionen erfasst werden, es können aber auch die Ländercodes angegeben werden. Dies ist bereits in der MS so und hat sich nicht geändert. Das Format ist alphanumerisch und kann somit sowohl Zahlen wie Buchstaben enthalten. </li>
-</ul>
+- Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a>
+-	Für die aussereuropäischen Länder können Regionen erfasst werden, es können aber auch die Ländercodes angegeben werden. Dies ist bereits in der MS so und hat sich nicht geändert. Das Format ist alphanumerisch und kann somit sowohl Zahlen wie Buchstaben enthalten.
 {{</collapsibleBlock>}}
 
 ### Variable "versicherungsklasse"
@@ -74,8 +66,6 @@ Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missing
 
 10. Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit einer «Flex-Versicherung», die Information zu gewinnen und mit «8 = andere» zu hinterlegen. Gibt es bei den Auswertungen später ein Problem bzw. welche Auswirkungen ergeben sich auf die Statistik, wenn wir «8=andere» nicht angeben (können)?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li>	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden. </li>
-<li>	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet.  </li>
-</ul>
+-	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
+-	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -9,6 +9,7 @@ keywords: []
 
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="admninistratives">}}
+{{<numberedList>}}
 
 1. Werden im SpiGes-Datensatz die Fallklammer-Fälle (=zusammengeführter Fall) erwartet? ANQ erwartet im Bereich der Psychiatrie einen Datensatz mit den Einzelfällen, also nicht zusammengeführte Fälle. Gibt es bereits einen Austausch zwischen Ihnen und ANQ, bzgl. Nutzung des SpiGes-Datensatzes?
 {{<collapsibleBlock groupId="admninistratives">}}
@@ -82,4 +83,5 @@ Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missing
 -	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -44,8 +44,8 @@ Rückführung eines Patienten oder einer Patientin mit Schweizer Hauptwohnsitz a
 
 7. Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
 {{<collapsibleBlock groupId="admninistratives">}}
-Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden: <br />
-austritt_aufenthalt: 2 = Krankenheim, Pflegeheim <br />
+Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden:        
+austritt_aufenthalt: 2 = Krankenheim, Pflegeheim        
 eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb  
 {{</collapsibleBlock>}}
 

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -99,7 +99,7 @@ Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit ei
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 -	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
--	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet. 
+-	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet.
 {{</markdown>}}
 {{</collapsibleBlock>}}
 {{</listItem>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -11,8 +11,8 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
-<ul>
-<li>	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. </li>
-<li>	Siehe Link: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html </a> </li>
-</ul>
+
+-	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
+-	Siehe Link: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html </a> 
+
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -11,12 +11,14 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 {{<numberedList>}}
-1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
+{{<listItem>}}
+Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
 -	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
 -	Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
@@ -14,3 +15,4 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 -	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
 -	Siehe Link: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html </a> 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
+{{<numberedList>}}
 1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
@@ -17,4 +18,5 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 -	Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -15,6 +15,7 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
+
 - Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen.
 - Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
 {{</markdown>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -15,6 +15,6 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 {{<markdown>}}
 -	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
 -	Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
-{{<markdown>}}
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -11,8 +11,6 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
-
 -	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
 -	Siehe Link: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html </a> 
-
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -12,7 +12,9 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
+{{<markdown>}}
 -	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
--	Siehe Link: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html </a> 
+-	Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
+{{<markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/de/FAQ/Falldaten/3_psychiatrie.md
@@ -15,8 +15,8 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 Variable psy_zivilstand: Was ist mit dem Code "5 = unverheiratet" gemeint bzw. wie unterscheidet sich dieser von ledig etc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
--	Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen. 
--	Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
+- Die Codeliste der Variable Zivilstand wird beim BFS einheitlich genutzt. Der Zivilstand «Unverheiratet» kann als Folge einer Ungültigerklärung der letzten Ehe oder als Folge einer Verschollenerklärung des letzten Ehepartners bzw. der letzten Ehepartnerin entstehen.
+- Siehe Link: [https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/bevoelkerung/stand-entwicklung/zivilstand.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
 {{</listItem>}}

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -12,7 +12,7 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 {{<numberedList>}}
 {{<listItem>}}
-POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
+POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird?
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Patientensicherheit verwendet werden. Siehe z. B. die Mitteilung des Kantons Zürich zu diesem Thema. [Present on admission - Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf)

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -33,7 +33,7 @@ ND I79.2* Periphere Angiopathie bei anderenorts klassifizierten Krankheiten
 ND H36.0* Retinopathia diabetica      
 ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus       
 …wird wie folgt in **SpiGes** erfasst:  
-{{</markdown>}}     
+{{</markdown>}}
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -16,7 +16,6 @@ Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Pat
 
 2. Variable «diagnose_zusatz»: Welche Angaben müssen hier bei Stern-Kodes und Kodes mit Ausrufezeichen gemacht werden?
 {{<collapsibleBlock groupId="diagnose">}}
-
 -	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. 
 -	Stern-Kodes werden nicht als solche markiert, die Vergabe erfolgt gemäss ICD-10-GM. 
 

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="diagnose">}}
 
+{{<numberedList>}}
 1. POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
@@ -110,4 +111,5 @@ ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des 
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -16,10 +16,10 @@ Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Pat
 
 2. Variable «diagnose_zusatz»: Welche Angaben müssen hier bei Stern-Kodes und Kodes mit Ausrufezeichen gemacht werden?
 {{<collapsibleBlock groupId="diagnose">}}
-<ul>
-<li>	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. </li>
-<li>	Stern-Kodes werden nicht als solche markiert, die Vergabe erfolgt gemäss ICD-10-GM. </li>
-</ul>
+
+-	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. 
+-	Stern-Kodes werden nicht als solche markiert, die Vergabe erfolgt gemäss ICD-10-GM. 
+
 <p>
 <b>Beispiel 4</b> im Kodierhandbuch (Seite 38) <br />
 HD E10.73† Diabetes mellitus, Typ 1, mit multiplen Komplikationen, als entgleist bezeichnet <br />

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -20,13 +20,12 @@ Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Pat
 -	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. 
 -	Stern-Kodes werden nicht als solche markiert, die Vergabe erfolgt gemäss ICD-10-GM. 
 
-<p>
-<b>Beispiel 4</b> im Kodierhandbuch (Seite 38) <br />
-HD E10.73† Diabetes mellitus, Typ 1, mit multiplen Komplikationen, als entgleist bezeichnet <br />
-ND I79.2* Periphere Angiopathie bei anderenorts klassifizierten Krankheiten <br />
-ND H36.0* Retinopathia diabetica <br />
-ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus <br />
-…wird wie folgt in <b>SpiGes</b> erfasst: <br />
+**Beispiel 4** im Kodierhandbuch (Seite 38)      
+HD E10.73† Diabetes mellitus, Typ 1, mit multiplen Komplikationen, als entgleist bezeichnet       
+ND I79.2* Periphere Angiopathie bei anderenorts klassifizierten Krankheiten       
+ND H36.0* Retinopathia diabetica      
+ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus       
+…wird wie folgt in **SpiGes** erfasst:       
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -54,17 +53,15 @@ ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus <br />
     <td> E10.73 </td>
   </tr>
 </table>
-</p>
 
-<p>
-<b>Beispiel 4</b> im Koderhandbuch (Seite 40) <br />
-HD S37.03 Komplette Ruptur des Nierenparenchyms <br />
-L 2 <br />
-ND V99! Transportmittelunfall <br />
-ND S36.03 Rissverletzung der Milz mit Beteiligung des Parenchyms <br />
-ND S36.49 Verletzung sonstiger und mehrerer Teile des Dünndarmes <br />
-ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des Beckens) mit Verbindung zu einer intraabdominalen Verletzung <br />
-…wird wie folgt in SpiGes erfasst: <br />
+**Beispiel 4** im Koderhandbuch (Seite 40)       
+HD S37.03 Komplette Ruptur des Nierenparenchyms       
+L 2       
+ND V99! Transportmittelunfall       
+ND S36.03 Rissverletzung der Milz mit Beteiligung des Parenchyms      
+ND S36.49 Verletzung sonstiger und mehrerer Teile des Dünndarmes      
+ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des Beckens) mit Verbindung zu einer intraabdominalen Verletzung      
+…wird wie folgt in SpiGes erfasst:      
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -107,5 +104,4 @@ ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des 
     <td> S37.03 </td>
   </tr>
 </table>
-</p>
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1. POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
@@ -104,3 +105,4 @@ ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des 
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -11,14 +11,17 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 {{<numberedList>}}
-1. POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
+{{<listItem>}}
+POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Patientensicherheit verwendet werden. Siehe z. B. die Mitteilung des Kantons Zürich zu diesem Thema. [Present on admission - Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Variable «diagnose_zusatz»: Welche Angaben müssen hier bei Stern-Kodes und Kodes mit Ausrufezeichen gemacht werden?
+{{<listItem>}}
+ Variable «diagnose_zusatz»: Welche Angaben müssen hier bei Stern-Kodes und Kodes mit Ausrufezeichen gemacht werden?
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 -	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. 
@@ -111,5 +114,7 @@ ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des 
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/4_diagnose.md
+++ b/content/de/FAQ/Falldaten/4_diagnose.md
@@ -12,11 +12,14 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1. POA-Variable: Könnten Sie uns bitte sagen, zu welchem Zweck die Variable diagnose_poa verwendet wird? 
 {{<collapsibleBlock groupId="diagnose">}}
-Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Patientensicherheit verwendet werden. Siehe z. B. die Mitteilung des Kantons Zürich zu diesem Thema. <a href="https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf"> Present on admission - Informationen zur Erfassung (zh.ch)</a>
+{{<markdown>}}
+Die Angabe «POA» kann unter anderem zur Verbesserung der Qualität und der Patientensicherheit verwendet werden. Siehe z. B. die Mitteilung des Kantons Zürich zu diesem Thema. [Present on admission - Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf)
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Variable «diagnose_zusatz»: Welche Angaben müssen hier bei Stern-Kodes und Kodes mit Ausrufezeichen gemacht werden?
 {{<collapsibleBlock groupId="diagnose">}}
+{{<markdown>}}
 -	Bei Stern-Kodes wird hier der zugehörige Kreuz-Kode angegeben. Bei Kodes mit Ausrufezeichen, der zu präzisierende Kode. 
 -	Stern-Kodes werden nicht als solche markiert, die Vergabe erfolgt gemäss ICD-10-GM. 
 
@@ -25,7 +28,8 @@ HD E10.73† Diabetes mellitus, Typ 1, mit multiplen Komplikationen, als entglei
 ND I79.2* Periphere Angiopathie bei anderenorts klassifizierten Krankheiten       
 ND H36.0* Retinopathia diabetica      
 ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus       
-…wird wie folgt in **SpiGes** erfasst:       
+…wird wie folgt in **SpiGes** erfasst:  
+{{</markdown>}}     
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -53,7 +57,7 @@ ND N08.3* Glomeruläre Krankheiten bei Diabetes mellitus
     <td> E10.73 </td>
   </tr>
 </table>
-
+{{<markdown>}}
 **Beispiel 4** im Koderhandbuch (Seite 40)       
 HD S37.03 Komplette Ruptur des Nierenparenchyms       
 L 2       
@@ -62,6 +66,7 @@ ND S36.03 Rissverletzung der Milz mit Beteiligung des Parenchyms
 ND S36.49 Verletzung sonstiger und mehrerer Teile des Dünndarmes      
 ND S31.83! Offene Wunde (jeder Teil des Abdomens, der Lumbosakralgegend und des Beckens) mit Verbindung zu einer intraabdominalen Verletzung      
 …wird wie folgt in SpiGes erfasst:      
+{{</markdown>}}
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
@@ -38,3 +39,4 @@ Das BFS ist sich bewusst, dass bei Einführung dieser neuen Angabe die Daten unv
 Wie viele Operateure einer Operation angerechnet werden können, ist eine konzeptuelle Frage und kann von Kanton zu Kanton unterschiedlich sein (in der Regel 2 ist ein Richtwert!). Technisch lassen sich mehrere Operierende erfassen.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -12,6 +12,7 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
+{{<markdown>}}
 - Gemäss Variablenbeschreibung gilt:        
 Eindeutige, fortlaufende Nummer der Behandlung.         
 1 = Behandlung 1        
@@ -26,6 +27,7 @@ Für die Reihenfolge der Behandlungen sind die folgenden Kriterien empfohlen:
 5. Weitere Prozeduren 
 
 - Für die HoNOS-Items würden wir eine chronologische Nummerierung empfehlen (frühere HoNOS-Messungen = tiefere IDs, spätere HoNOS-Messungen = höhere IDs).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Wir sorgen uns etwas, dass insbesondere in der Anfangszeit diese Daten nicht vollständig erfasst werden und es zu vielen Nacharbeiten kommen könnte. Daher würden wir gern bei den betroffenen CHOP-Codes das Feld als Muss-Feld definieren. Gibt es für den CHOP-Katalog eine Zuordnung, welche Codes als Operativ bzw. interventionell gelten?

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,8 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 {{<numberedList>}}
-1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
+{{<listItem>}}
+Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
 - Gemäss Variablenbeschreibung gilt:        
@@ -30,17 +31,23 @@ Für die Reihenfolge der Behandlungen sind die folgenden Kriterien empfohlen:
 - Für die HoNOS-Items würden wir eine chronologische Nummerierung empfehlen (frühere HoNOS-Messungen = tiefere IDs, spätere HoNOS-Messungen = höhere IDs).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wir sorgen uns etwas, dass insbesondere in der Anfangszeit diese Daten nicht vollständig erfasst werden und es zu vielen Nacharbeiten kommen könnte. Daher würden wir gern bei den betroffenen CHOP-Codes das Feld als Muss-Feld definieren. Gibt es für den CHOP-Katalog eine Zuordnung, welche Codes als Operativ bzw. interventionell gelten?
+{{<listItem>}}
+Wir sorgen uns etwas, dass insbesondere in der Anfangszeit diese Daten nicht vollständig erfasst werden und es zu vielen Nacharbeiten kommen könnte. Daher würden wir gern bei den betroffenen CHOP-Codes das Feld als Muss-Feld definieren. Gibt es für den CHOP-Katalog eine Zuordnung, welche Codes als Operativ bzw. interventionell gelten?
 {{<collapsibleBlock groupId="behandlungen">}}
 Das BFS ist sich bewusst, dass bei Einführung dieser neuen Angabe die Daten unvollständig sein werden. Nach der üblichen Konsolidierungsphase wird sich zeigen, welche Präzisierungen nötig sind. Es ist gar nicht möglich, für jeden CHOP-Kode eindeutig zu bestimmen, ob er eine Angabe der Zeit erfordert oder nicht. Es sind andere Merkmale, die hier massgeblich sind: ob die Behandlung in einem Zusammenhang mit der Benützung eines Operationssaals oder eines Herzkatheterlabors steht.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Operierende: Hier haben wir ein Verständnisproblem bei der Interpretation der Vorgaben des XML-Files. In der Variablenbeschreibung steht, dass pro Operation maximal zwei Operierende angerechnet werden können. In der Übersicht ist beim Attribut aber nicht zu erkennen, ob dies mehrfach exportiert werden kann.
+{{<listItem>}}
+Operierende: Hier haben wir ein Verständnisproblem bei der Interpretation der Vorgaben des XML-Files. In der Variablenbeschreibung steht, dass pro Operation maximal zwei Operierende angerechnet werden können. In der Übersicht ist beim Attribut aber nicht zu erkennen, ob dies mehrfach exportiert werden kann.
 {{<insertImage image="Image1.jpg" class="edge max-w-90">}}
 {{<collapsibleBlock groupId="behandlungen">}}
 Wie viele Operateure einer Operation angerechnet werden können, ist eine konzeptuelle Frage und kann von Kanton zu Kanton unterschiedlich sein (in der Regel 2 ist ein Richtwert!). Technisch lassen sich mehrere Operierende erfassen.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -12,25 +12,20 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
 
-- Gemäss Variablenbeschreibung gilt: <br />
-Eindeutige, fortlaufende Nummer der Behandlung. <br />
-1 = Behandlung 1 <br />
-2 = Behandlung 2 <br />
-3 = Behandlung 3 <br />
-(…) etc. -> Unbegrenzt <br />
+- Gemäss Variablenbeschreibung gilt:        
+Eindeutige, fortlaufende Nummer der Behandlung.         
+1 = Behandlung 1        
+2 = Behandlung 2        
+3 = Behandlung 3        
+(…) etc. -> Unbegrenzt      
 Für die Reihenfolge der Behandlungen sind die folgenden Kriterien empfohlen:
-<ol>
-- Prozeduren zur Behandlung der Hauptdiagnose 
-- Prozeduren zur Behandlung der Nebendiagnosen 
-- Prozeduren zur Bestimmung der Hauptdiagnose 
-- Prozeduren zur Bestimmung der Nebendiagnosen 
-- Weitere Prozeduren 
-</ol>
+1. Prozeduren zur Behandlung der Hauptdiagnose 
+2. Prozeduren zur Behandlung der Nebendiagnosen 
+3. Prozeduren zur Bestimmung der Hauptdiagnose 
+4. Prozeduren zur Bestimmung der Nebendiagnosen 
+5. Weitere Prozeduren 
 
--
-Für die HoNOS-Items würden wir eine chronologische Nummerierung empfehlen (frühere HoNOS-Messungen = tiefere IDs, spätere HoNOS-Messungen = höhere IDs).
-
-
+- Für die HoNOS-Items würden wir eine chronologische Nummerierung empfehlen (frühere HoNOS-Messungen = tiefere IDs, spätere HoNOS-Messungen = höhere IDs).
 {{</collapsibleBlock>}}
 
 2. Wir sorgen uns etwas, dass insbesondere in der Anfangszeit diese Daten nicht vollständig erfasst werden und es zu vielen Nacharbeiten kommen könnte. Daher würden wir gern bei den betroffenen CHOP-Codes das Feld als Muss-Feld definieren. Gibt es für den CHOP-Katalog eine Zuordnung, welche Codes als Operativ bzw. interventionell gelten?

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,6 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
-
 - Gemäss Variablenbeschreibung gilt:        
 Eindeutige, fortlaufende Nummer der Behandlung.         
 1 = Behandlung 1        

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -11,8 +11,8 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
-<ul>
-<li> Gemäss Variablenbeschreibung gilt: <br />
+
+- Gemäss Variablenbeschreibung gilt: <br />
 Eindeutige, fortlaufende Nummer der Behandlung. <br />
 1 = Behandlung 1 <br />
 2 = Behandlung 2 <br />
@@ -20,17 +20,17 @@ Eindeutige, fortlaufende Nummer der Behandlung. <br />
 (…) etc. -> Unbegrenzt <br />
 Für die Reihenfolge der Behandlungen sind die folgenden Kriterien empfohlen:
 <ol>
-<li> Prozeduren zur Behandlung der Hauptdiagnose </li>
-<li> Prozeduren zur Behandlung der Nebendiagnosen </li>
-<li> Prozeduren zur Bestimmung der Hauptdiagnose </li>
-<li> Prozeduren zur Bestimmung der Nebendiagnosen </li>
-<li> Weitere Prozeduren </li>
+- Prozeduren zur Behandlung der Hauptdiagnose 
+- Prozeduren zur Behandlung der Nebendiagnosen 
+- Prozeduren zur Bestimmung der Hauptdiagnose 
+- Prozeduren zur Bestimmung der Nebendiagnosen 
+- Weitere Prozeduren 
 </ol>
-</li>
-<li>
+
+-
 Für die HoNOS-Items würden wir eine chronologische Nummerierung empfehlen (frühere HoNOS-Messungen = tiefere IDs, spätere HoNOS-Messungen = höhere IDs).
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 2. Wir sorgen uns etwas, dass insbesondere in der Anfangszeit diese Daten nicht vollständig erfasst werden und es zu vielen Nacharbeiten kommen könnte. Daher würden wir gern bei den betroffenen CHOP-Codes das Feld als Muss-Feld definieren. Gibt es für den CHOP-Katalog eine Zuordnung, welche Codes als Operativ bzw. interventionell gelten?

--- a/content/de/FAQ/Falldaten/5_behandlungen.md
+++ b/content/de/FAQ/Falldaten/5_behandlungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
+{{<numberedList>}}
 1. Variable «behandlung_id»: Gibt es hier Empfehlungen für die umzusetzende Reihenfolge in der Psychiatrie? Gerade die HoNOS-Items, die als CHOPs geliefert werden, sind ja diagnose- bzw. behandlungsunspezifisch.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
@@ -41,4 +42,5 @@ Das BFS ist sich bewusst, dass bei Einführung dieser neuen Angabe die Daten unv
 Wie viele Operateure einer Operation angerechnet werden können, ist eine konzeptuelle Frage und kann von Kanton zu Kanton unterschiedlich sein (in der Regel 2 ist ein Richtwert!). Technisch lassen sich mehrere Operierende erfassen.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/6_medikamente.md
+++ b/content/de/FAQ/Falldaten/6_medikamente.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="medikamente">}}
 
 1. Variable «medi_id»: Die Leistungsnummern können bei unseren Kunden alphanumerisch sein, die Variable ist nur numerisch vorgesehen. Wäre es hier auch möglich, den Pharmacode oder den GTIN zu exportieren?
@@ -14,3 +15,4 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="medikamente">}}
 Diese Variable musste aus rein technischen Gründen hinzugefügt werden (XML Struktur) und stellt eine eindeutige Zeilennummer der thematischen Tabelle «Medikamente» dar. Solange die Variable eindeutig und vollständig ausgefüllt wird, wären theoretisch auch Pharmacode oder GTIN als Angabe möglich. Das BFS bezweifelt jedoch, ob diese Bedingungen für restlos alle Medikamente eingehalten werden könnten. Für gewisse liegen diese Infos einfach noch nicht vor.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/6_medikamente.md
+++ b/content/de/FAQ/Falldaten/6_medikamente.md
@@ -10,9 +10,10 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="medikamente">}}
 
+{{<numberedList>}}
 1. Variable «medi_id»: Die Leistungsnummern können bei unseren Kunden alphanumerisch sein, die Variable ist nur numerisch vorgesehen. Wäre es hier auch möglich, den Pharmacode oder den GTIN zu exportieren?
 {{<collapsibleBlock groupId="medikamente">}}
 Diese Variable musste aus rein technischen Gründen hinzugefügt werden (XML Struktur) und stellt eine eindeutige Zeilennummer der thematischen Tabelle «Medikamente» dar. Solange die Variable eindeutig und vollständig ausgefüllt wird, wären theoretisch auch Pharmacode oder GTIN als Angabe möglich. Das BFS bezweifelt jedoch, ob diese Bedingungen für restlos alle Medikamente eingehalten werden könnten. Für gewisse liegen diese Infos einfach noch nicht vor.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/6_medikamente.md
+++ b/content/de/FAQ/Falldaten/6_medikamente.md
@@ -11,9 +11,12 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="medikamente">}}
 
 {{<numberedList>}}
-1. Variable «medi_id»: Die Leistungsnummern können bei unseren Kunden alphanumerisch sein, die Variable ist nur numerisch vorgesehen. Wäre es hier auch möglich, den Pharmacode oder den GTIN zu exportieren?
+{{<listItem>}}
+Variable «medi_id»: Die Leistungsnummern können bei unseren Kunden alphanumerisch sein, die Variable ist nur numerisch vorgesehen. Wäre es hier auch möglich, den Pharmacode oder den GTIN zu exportieren?
 {{<collapsibleBlock groupId="medikamente">}}
 Diese Variable musste aus rein technischen Gründen hinzugefügt werden (XML Struktur) und stellt eine eindeutige Zeilennummer der thematischen Tabelle «Medikamente» dar. Solange die Variable eindeutig und vollständig ausgefüllt wird, wären theoretisch auch Pharmacode oder GTIN als Angabe möglich. Das BFS bezweifelt jedoch, ob diese Bedingungen für restlos alle Medikamente eingehalten werden könnten. Für gewisse liegen diese Infos einfach noch nicht vor.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -11,12 +11,15 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
 {{<numberedList>}}
-1. Wird für jede gestellte Rechnung - und jedes Zusatzentgelt - eine Zeile exportiert?
+{{<listItem>}}
+Wird für jede gestellte Rechnung - und jedes Zusatzentgelt - eine Zeile exportiert?
 {{<collapsibleBlock groupId="rechnungen">}}
 Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen anzugeben. Wurde z.B. für einen grundversicherten Fall eine Fallpauschale sowie ein Zusatzentgelt abgerechnet und der Grundversicherung sowie dem Kanton in Rechnung gestellt, so sind vier Zeilen zu liefern (1.Pauschale an Kanton, 2.Zusatzentgelt an Kanton, 3.Pauschale an Versicherer, 4.Zusatzentgelt an Versicherer).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wie werden die entsprechenden Felder ausgefüllt für Rechnungen, die nicht über SwissDRG, TARPSY oder ST Reha abgerechnet werden?
+{{<listItem>}}
+Wie werden die entsprechenden Felder ausgefüllt für Rechnungen, die nicht über SwissDRG, TARPSY oder ST Reha abgerechnet werden?
 {{<collapsibleBlock groupId="rechnungen">}}
 {{<markdown>}}
 -	Grundsätzlich analog Forum Datenaustausch, einfach nur für die stationären Behandlungen. 
@@ -24,5 +27,7 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 -	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -17,9 +17,11 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 
 2. Wie werden die entsprechenden Felder ausgefüllt für Rechnungen, die nicht über SwissDRG, TARPSY oder ST Reha abgerechnet werden?
 {{<collapsibleBlock groupId="rechnungen">}}
+{{<markdown>}}
 -	Grundsätzlich analog Forum Datenaustausch, einfach nur für die stationären Behandlungen. 
 -	Tariftyp, Betrag und Menge sollten klar sein. 
 -	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
 1. Wird für jede gestellte Rechnung - und jedes Zusatzentgelt - eine Zeile exportiert?
@@ -20,3 +21,5 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 -	Tariftyp, Betrag und Menge sollten klar sein. 
 -	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,7 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 
 2. Wie werden die entsprechenden Felder ausgefüllt für Rechnungen, die nicht über SwissDRG, TARPSY oder ST Reha abgerechnet werden?
 {{<collapsibleBlock groupId="rechnungen">}}
-
 -	Grundsätzlich analog Forum Datenaustausch, einfach nur für die stationären Behandlungen. 
 -	Tariftyp, Betrag und Menge sollten klar sein. 
 -	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
-
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,9 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 
 2. Wie werden die entsprechenden Felder ausgefüllt für Rechnungen, die nicht über SwissDRG, TARPSY oder ST Reha abgerechnet werden?
 {{<collapsibleBlock groupId="rechnungen">}}
-<ul>
-<li>	Grundsätzlich analog Forum Datenaustausch, einfach nur für die stationären Behandlungen. </li>
-<li>	Tariftyp, Betrag und Menge sollten klar sein. </li>
-<li>	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. </li>
-</ul>
+
+-	Grundsätzlich analog Forum Datenaustausch, einfach nur für die stationären Behandlungen. 
+-	Tariftyp, Betrag und Menge sollten klar sein. 
+-	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
+
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/7_rechnungen.md
+++ b/content/de/FAQ/Falldaten/7_rechnungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
+{{<numberedList>}}
 1. Wird für jede gestellte Rechnung - und jedes Zusatzentgelt - eine Zeile exportiert?
 {{<collapsibleBlock groupId="rechnungen">}}
 Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen anzugeben. Wurde z.B. für einen grundversicherten Fall eine Fallpauschale sowie ein Zusatzentgelt abgerechnet und der Grundversicherung sowie dem Kanton in Rechnung gestellt, so sind vier Zeilen zu liefern (1.Pauschale an Kanton, 2.Zusatzentgelt an Kanton, 3.Pauschale an Versicherer, 4.Zusatzentgelt an Versicherer).
@@ -23,5 +24,5 @@ Es ist dieselbe Granularität, wie die Zeilen auf den verschickten Rechnungen an
 -	Felder, die bei anderen Tarifen keinen Sinn machen, können leer gelassen werden. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/de/FAQ/Falldaten/8_patientenbewegung.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 1. Gelten der Eintritt und Austritt auch als Episode?
@@ -50,3 +51,5 @@ Ja, Datum und Stundenangabe müssen für alle Episoden sowohl für den Beginn al
 Ja, bei externen ambulanten Behandlungen kann die BUR-Nummer des behandelnden  Standorts angegeben werden, falls diese bekannt ist.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/de/FAQ/Falldaten/8_patientenbewegung.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
+{{<numberedList>}}
 1. Gelten der Eintritt und Austritt auch als Episode?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Eintritt und Austritt werden wie bisher unter Eintrittsdatum und Austrittsdatum angegeben. Falls der Fall nicht transferiert wurde, werden keine Episoden erfasst. Sobald es aber zu einem Transfer kommt (z.B. ein Zwischenaustritt) wird Episode 1 vom Eintrittsdatum bis zum Zwischenaustritt erfasst. Episode 2 beginnt beim Zwischenausstritt und endet mit dem Wiedereintritt. Episode 3 beginnt mit dem Wiedereintritt und endet mit dem nächsten Transfer (z.B. Urlaub). Dies kann für den gleichen Fall in mehrere Episoden enden (siehe Abbildung). Die letzte Episode (9) endet mit dem Austrittsdatum. Episoden sind die Abschnitte vor und nach einem Standortwechsel eines Falls, Zwischenaustritte / Wiedereintritte, externe ambulante Behandlungen, Urlaube und Belastungserprobungen.
@@ -51,5 +52,5 @@ Ja, Datum und Stundenangabe müssen für alle Episoden sowohl für den Beginn al
 Ja, bei externen ambulanten Behandlungen kann die BUR-Nummer des behandelnden  Standorts angegeben werden, falls diese bekannt ist.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/de/FAQ/Falldaten/8_patientenbewegung.md
@@ -11,46 +11,63 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 {{<numberedList>}}
-1. Gelten der Eintritt und Austritt auch als Episode?
+{{<listItem>}}
+Gelten der Eintritt und Austritt auch als Episode?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Eintritt und Austritt werden wie bisher unter Eintrittsdatum und Austrittsdatum angegeben. Falls der Fall nicht transferiert wurde, werden keine Episoden erfasst. Sobald es aber zu einem Transfer kommt (z.B. ein Zwischenaustritt) wird Episode 1 vom Eintrittsdatum bis zum Zwischenaustritt erfasst. Episode 2 beginnt beim Zwischenausstritt und endet mit dem Wiedereintritt. Episode 3 beginnt mit dem Wiedereintritt und endet mit dem nächsten Transfer (z.B. Urlaub). Dies kann für den gleichen Fall in mehrere Episoden enden (siehe Abbildung). Die letzte Episode (9) endet mit dem Austrittsdatum. Episoden sind die Abschnitte vor und nach einem Standortwechsel eines Falls, Zwischenaustritte / Wiedereintritte, externe ambulante Behandlungen, Urlaube und Belastungserprobungen.
 {{<insertImage image="Image3.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wird ein Fall, der den Standort wechselt, in beiden Standorten geführt?
+{{<listItem>}}
+Wird ein Fall, der den Standort wechselt, in beiden Standorten geführt?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Nein, jeder Fall wird nur am Hauptstandort geführt, auch wenn er innerhalb eines Spitals (BURGESV) von einem Standort zum anderen verlegt wird. Wechselt ein Patient in ein anderes Spital (BURGESV), ist ein neuer Fall zu eröffnen. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Variablen "wiedereintritt_aufenthalt" und "grund_wiedereintritt": Wieso können diese Angaben nur für A Fälle gemacht werden, wenn sämtliche Episodenangaben für ABC Fälle gedacht sind?
+{{<listItem>}}
+Variablen "wiedereintritt_aufenthalt" und "grund_wiedereintritt": Wieso können diese Angaben nur für A Fälle gemacht werden, wenn sämtliche Episodenangaben für ABC Fälle gedacht sind?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Abklärungen mit der SwissDRG AG haben ergeben, dass die beiden Variablen "wiedereintritt_aufenthalt" und "grund_wiedereintritt" für Statistikfälle ABC angegeben werden können. Wir werden dies im Variablenbeschrieb 1.4 anpassen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. episode_id: Wir sind der Meinung, dass für unsere Klinik bei den stationären Fällen keine Episoden unterschieden werden müssen, da wir keine Standortwechsel innerhalb des Spitals verzeichnen. Ist das unsererseits richtig verstanden?
+{{<listItem>}}
+episode_id: Wir sind der Meinung, dass für unsere Klinik bei den stationären Fällen keine Episoden unterschieden werden müssen, da wir keine Standortwechsel innerhalb des Spitals verzeichnen. Ist das unsererseits richtig verstanden?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Die Vermutung trifft zu, was Episoden aufgrund von Standortwechseln betrifft. Episoden aufgrund von Zwischenaustritten/Wiedereintritten, Urlaub, Belastungserprobung oder ambulanten Behandlungen auswärts sind jedoch zu erfassen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Verstehen wir dies richtig, dass z.B. der Eintritt bis zur ambulanten Behandlung auswärts (siehe Abbildung unten) bereits eine Episode ist? Wir haben also zwischen Urlauben, Belastungserprobungen und auswärtigen Behandlungen immer eine episode_art="1"?
+{{<listItem>}}
+Verstehen wir dies richtig, dass z.B. der Eintritt bis zur ambulanten Behandlung auswärts (siehe Abbildung unten) bereits eine Episode ist? Wir haben also zwischen Urlauben, Belastungserprobungen und auswärtigen Behandlungen immer eine episode_art="1"?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Richtig
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Wir haben im Beispiel (siehe Abbildung unten) keine Standortwechsel innerhalb desselben Spitals. Verstehen wir es richtig, dass bei der episode_art="1" immer die BUR Nummer Standort des Spitals anzugeben ist?
+{{<listItem>}}
+Wir haben im Beispiel (siehe Abbildung unten) keine Standortwechsel innerhalb desselben Spitals. Verstehen wir es richtig, dass bei der episode_art="1" immer die BUR Nummer Standort des Spitals anzugeben ist?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Richtig
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Die Zeitangabe für die Rückkehr von der ambulanten Behandlung auswärts wird unseres Wissens nach nicht dokumentiert. Eventuell wird dies aber in den Krankenhausinformationssystemen der Spitäler erfasst. Ist diese Angabe zwingend?
+{{<listItem>}}
+Die Zeitangabe für die Rückkehr von der ambulanten Behandlung auswärts wird unseres Wissens nach nicht dokumentiert. Eventuell wird dies aber in den Krankenhausinformationssystemen der Spitäler erfasst. Ist diese Angabe zwingend?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Ja, Datum und Stundenangabe müssen für alle Episoden sowohl für den Beginn als auch für das Ende geliefert werden. Falls das Ende einer ambulanten auswärtigen Behandlung nicht erfasst wird, empfehlen wir diese Erfassung zu ergänzen. Sollte dies nicht (so rasch) möglich sein, empfehlen wir für ambulante auswärtige Behandlungen einen Standarddauer zu verwenden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. Die Angabe der BURNR des auswärts behandelnden Spitals ist fakultativ, richtig? 
+{{<listItem>}}
+Die Angabe der BURNR des auswärts behandelnden Spitals ist fakultativ, richtig? 
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Ja, bei externen ambulanten Behandlungen kann die BUR-Nummer des behandelnden  Standorts angegeben werden, falls diese bekannt ist.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -17,7 +17,9 @@ Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle di
 
 2. Zuschläge für Anlagenutzungskosten (ANK) bei den Einzelkosten:  Auf den Einzelkosten (Medizinischer Bedarf 400 und 401) dürfen gemäss REKOLE® ANK-Zuschläge erfasst werden. Für diese KTR-Variablen existieren in SpiGes und im SwissDRG Kostendatensatz aber im Gegensatz zu den Gemeinkosten keine separaten ANK-Variablen, auf denen die Anlagenutzungskosten gemäss REKOLE angegeben werden können. In ITAR_K müssen die Konten 400 und 401 ohne ANK-Zuschläge angegeben werden. Wie ist mit diesen ANK-Zuschlägen auf den Konten 400 und 401 zu verfahren?
 {{<collapsibleBlock groupId="kostentraeger">}}
+{{<markdown>}}
 -	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). 
 -	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -11,17 +11,22 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 {{<numberedList>}}
-1. Wie sollen die Kosten für forensische C-Fälle (mehrere Jahre Liegedauer) eingereicht werden? Für den ganzen Fall (ganze Liegedauer) oder nur die Kosten für das jeweilige Kalenderjahr und der Rest über Abgrenzungen?
+{{<listItem>}}
+Wie sollen die Kosten für forensische C-Fälle (mehrere Jahre Liegedauer) eingereicht werden? Für den ganzen Fall (ganze Liegedauer) oder nur die Kosten für das jeweilige Kalenderjahr und der Rest über Abgrenzungen?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle die Kosten über die ganze Falldauer. Für ambulante und nicht-fallbezogene Kostenträger auch die Kosten im Kalenderjahr. Siehe auch Spalte «Zeitbezug» der Variablenliste. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Zuschläge für Anlagenutzungskosten (ANK) bei den Einzelkosten:  Auf den Einzelkosten (Medizinischer Bedarf 400 und 401) dürfen gemäss REKOLE® ANK-Zuschläge erfasst werden. Für diese KTR-Variablen existieren in SpiGes und im SwissDRG Kostendatensatz aber im Gegensatz zu den Gemeinkosten keine separaten ANK-Variablen, auf denen die Anlagenutzungskosten gemäss REKOLE angegeben werden können. In ITAR_K müssen die Konten 400 und 401 ohne ANK-Zuschläge angegeben werden. Wie ist mit diesen ANK-Zuschlägen auf den Konten 400 und 401 zu verfahren?
+{{<listItem>}}
+Zuschläge für Anlagenutzungskosten (ANK) bei den Einzelkosten:  Auf den Einzelkosten (Medizinischer Bedarf 400 und 401) dürfen gemäss REKOLE® ANK-Zuschläge erfasst werden. Für diese KTR-Variablen existieren in SpiGes und im SwissDRG Kostendatensatz aber im Gegensatz zu den Gemeinkosten keine separaten ANK-Variablen, auf denen die Anlagenutzungskosten gemäss REKOLE angegeben werden können. In ITAR_K müssen die Konten 400 und 401 ohne ANK-Zuschläge angegeben werden. Wie ist mit diesen ANK-Zuschlägen auf den Konten 400 und 401 zu verfahren?
 {{<collapsibleBlock groupId="kostentraeger">}}
 {{<markdown>}}
 -	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). 
 -	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
+{{<numberedList>}}
 1. Wie sollen die Kosten für forensische C-Fälle (mehrere Jahre Liegedauer) eingereicht werden? Für den ganzen Fall (ganze Liegedauer) oder nur die Kosten für das jeweilige Kalenderjahr und der Rest über Abgrenzungen?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle die Kosten über die ganze Falldauer. Für ambulante und nicht-fallbezogene Kostenträger auch die Kosten im Kalenderjahr. Siehe auch Spalte «Zeitbezug» der Variablenliste. 
@@ -22,4 +23,5 @@ Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle di
 -	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 1. Wie sollen die Kosten für forensische C-Fälle (mehrere Jahre Liegedauer) eingereicht werden? Für den ganzen Fall (ganze Liegedauer) oder nur die Kosten für das jeweilige Kalenderjahr und der Rest über Abgrenzungen?
@@ -19,3 +20,4 @@ Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle di
 -	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). 
 -	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -16,8 +16,8 @@ Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle di
 
 2. Zuschläge für Anlagenutzungskosten (ANK) bei den Einzelkosten:  Auf den Einzelkosten (Medizinischer Bedarf 400 und 401) dürfen gemäss REKOLE® ANK-Zuschläge erfasst werden. Für diese KTR-Variablen existieren in SpiGes und im SwissDRG Kostendatensatz aber im Gegensatz zu den Gemeinkosten keine separaten ANK-Variablen, auf denen die Anlagenutzungskosten gemäss REKOLE angegeben werden können. In ITAR_K müssen die Konten 400 und 401 ohne ANK-Zuschläge angegeben werden. Wie ist mit diesen ANK-Zuschlägen auf den Konten 400 und 401 zu verfahren?
 {{<collapsibleBlock groupId="kostentraeger">}}
-<ul>
-<li>	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). </li>
-<li>	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. </li>
-</ul>
+
+-	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). 
+-	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
+
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/de/FAQ/Falldaten/9_kostentrager_fall.md
@@ -16,8 +16,6 @@ Für B- und C-Fälle sind die Kosten im Kalenderjahr anzugeben, für A-Fälle di
 
 2. Zuschläge für Anlagenutzungskosten (ANK) bei den Einzelkosten:  Auf den Einzelkosten (Medizinischer Bedarf 400 und 401) dürfen gemäss REKOLE® ANK-Zuschläge erfasst werden. Für diese KTR-Variablen existieren in SpiGes und im SwissDRG Kostendatensatz aber im Gegensatz zu den Gemeinkosten keine separaten ANK-Variablen, auf denen die Anlagenutzungskosten gemäss REKOLE angegeben werden können. In ITAR_K müssen die Konten 400 und 401 ohne ANK-Zuschläge angegeben werden. Wie ist mit diesen ANK-Zuschlägen auf den Konten 400 und 401 zu verfahren?
 {{<collapsibleBlock groupId="kostentraeger">}}
-
 -	Die ANK-Zuschläge sind auf den Konten 400 und 401 nicht zu erfassen. Sie sind jedoch in den Total-Variablen der ANK einzuschliessen (ktr_44_vkl / ktr_44_rekole). 
 -	Die Variable ktr_44_rekole wird mit der Version 1.4 der Schnittstelle von einer berechneten in eine erhobene Variable umgewandelt (und im XML hinzugefügt), so dass damit ein Total ANK REKOLE erhoben werden kann, das von der Summe der einzelnen KTR-Variablen abweicht. 
-
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -11,29 +11,40 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
 {{<numberedList>}}
-1. Was ist ein zweiter Identifikationsfaktor?
+{{<listItem>}}
+Was ist ein zweiter Identifikationsfaktor?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Der Begriff zweiter Identifikationsfaktor bezieht sich auf das Sicherheitsmerkmal, das Sie zusätzlich zum ersten Identifikationsfaktor, der Ihr CH-LOGIN-Passwort ist, eingeben müssen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Ist es möglich, nur ein CH-LOGIN für das Unternehmen/den Standort zu haben?
+{{<listItem>}}
+Ist es möglich, nur ein CH-LOGIN für das Unternehmen/den Standort zu haben?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, die CH-LOGIN ist persönlich. Da Ihre Identität verifiziert werden muss, um auf die SpiGes-Plattform zugreifen zu können, ist es daher unerlässlich, dass Ihr Konto persönlich ist. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Es gibt einen Wechsel des Mitarbeiters/der Mitarbeiterin im Unternehmen/am Standort, ist es möglich, das CH-LOGIN auf den neuen Mitarbeiter/die neue Mitarbeiterin zu übertragen?
+{{<listItem>}}
+Es gibt einen Wechsel des Mitarbeiters/der Mitarbeiterin im Unternehmen/am Standort, ist es möglich, das CH-LOGIN auf den neuen Mitarbeiter/die neue Mitarbeiterin zu übertragen?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, das CH-LOGIN ist persönlich. Da Ihre Identität verifiziert werden muss, um auf die SpiGes-Plattform zugreifen zu können, ist es daher unerlässlich, dass Ihr Konto persönlich ist. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ich habe bereits ein CH-LOGIN, muss ich ein neues erstellen?
+{{<listItem>}}
+Ich habe bereits ein CH-LOGIN, muss ich ein neues erstellen?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, Sie können Ihr CH-LOGIN verwenden. Sie müssen allerdings einen zweiten starken Faktor einrichten und dort die Videoidentifikation durchführen, falls dies auf Ihrem CH-LOGIN noch nicht geschehen ist. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Ist die Verbindung mit AGOV für die SpiGes-Anwendung möglich?
+{{<listItem>}}
+Ist die Verbindung mit AGOV für die SpiGes-Anwendung möglich?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, im Moment nicht.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
 1. Was ist ein zweiter Identifikationsfaktor?
@@ -33,3 +34,5 @@ Nein, Sie können Ihr CH-LOGIN verwenden. Sie müssen allerdings einen zweiten s
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, im Moment nicht.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/de/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
+{{<numberedList>}}
 1. Was ist ein zweiter Identifikationsfaktor?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Der Begriff zweiter Identifikationsfaktor bezieht sich auf das Sicherheitsmerkmal, das Sie zusätzlich zum ersten Identifikationsfaktor, der Ihr CH-LOGIN-Passwort ist, eingeben müssen.
@@ -34,5 +35,5 @@ Nein, Sie können Ihr CH-LOGIN verwenden. Sie müssen allerdings einen zweiten s
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Nein, im Moment nicht.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -11,19 +11,26 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 {{<numberedList>}}
-1. Welche zweiten Sicherheitsfaktoren kann ich verwenden?
+{{<listItem>}}
+Welche zweiten Sicherheitsfaktoren kann ich verwenden?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Für den Zugriff auf die SpiGes-Plattform ist ein starker zweiter Faktor erforderlich. Als stark gelten die folgenden zweiten Faktoren: Mobile ID und FIDO-Schlüssel.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Ist die Videoidentifikation für die Nutzung der SpiGes-Erhebungsplattform obligatorisch?
+{{<listItem>}}
+Ist die Videoidentifikation für die Nutzung der SpiGes-Erhebungsplattform obligatorisch?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Ja. Ohne die Videoidentifikation erreichen Sie nicht die QoA 50 (Quality of Authentication), die für den Zugang zur SpiGes-Erhebungsplattform erforderlich ist. Um diese Qualitätsstufe der Authentifizierung zu erreichen, muss der Nutzer über eine verifizierte elektronische Identität verfügen und nicht nur über eine selbstregistrierte.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Was ist eine verifizierte Identität, und was muss man tun, um eine solche zu erhalten?
+{{<listItem>}}
+Was ist eine verifizierte Identität, und was muss man tun, um eine solche zu erhalten?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Damit eine elektronische Identität als verifiziert gelten kann, muss ein amtlicher, mit einem Foto versehener Ausweis des Inhabers der elektronischen Identität geprüft, registriert und der Inhaber der elektronischen Identität korrekt identifiziert worden sein. Dazu müssen Sie diese kostenpflichtige (CHF 45.00) Videoidentifikation (VIPS) durchlaufen, bei der Ihre Identität von einer zertifizierten Person überprüft wird.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
+{{<numberedList>}}
 1. Welche zweiten Sicherheitsfaktoren kann ich verwenden?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Für den Zugriff auf die SpiGes-Plattform ist ein starker zweiter Faktor erforderlich. Als stark gelten die folgenden zweiten Faktoren: Mobile ID und FIDO-Schlüssel.
@@ -24,5 +25,5 @@ Ja. Ohne die Videoidentifikation erreichen Sie nicht die QoA 50 (Quality of Auth
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Damit eine elektronische Identität als verifiziert gelten kann, muss ein amtlicher, mit einem Foto versehener Ausweis des Inhabers der elektronischen Identität geprüft, registriert und der Inhaber der elektronischen Identität korrekt identifiziert worden sein. Dazu müssen Sie diese kostenpflichtige (CHF 45.00) Videoidentifikation (VIPS) durchlaufen, bei der Ihre Identität von einer zertifizierten Person überprüft wird.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/de/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 1. Welche zweiten Sicherheitsfaktoren kann ich verwenden?
@@ -23,3 +24,5 @@ Ja. Ohne die Videoidentifikation erreichen Sie nicht die QoA 50 (Quality of Auth
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Damit eine elektronische Identität als verifiziert gelten kann, muss ein amtlicher, mit einem Foto versehener Ausweis des Inhabers der elektronischen Identität geprüft, registriert und der Inhaber der elektronischen Identität korrekt identifiziert worden sein. Dazu müssen Sie diese kostenpflichtige (CHF 45.00) Videoidentifikation (VIPS) durchlaufen, bei der Ihre Identität von einer zertifizierten Person überprüft wird.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 1. Ich habe keine SIM-Karte, die neu genug ist, um die Mobile ID zu nutzen, was kann ich tun?
@@ -28,3 +29,5 @@ Nein. Die Mobile ID-Anwendung wird nicht als zweiter starker Sicherheitsfaktor f
 {{<collapsibleBlock groupId="mobile_id">}}
 Sie können einfach überprüfen, ob Ihre Mobile ID aktiv ist, indem Sie sie auf der Mobile ID-Website testen. Danach können Sie die Schritte befolgen, um sie als zweiten starken Sicherheitsfaktor zu Ihrem CH-LOGIN hinzuzufügen.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
+{{<numberedList>}}
 1. Ich habe keine SIM-Karte, die neu genug ist, um die Mobile ID zu nutzen, was kann ich tun?
 {{<collapsibleBlock groupId="mobile_id">}}
 Sie können bei Ihrem Telefonanbieter eine SIM-Karte der neuesten Generation bestellen. Sie können auch einen FIDO-Schlüssel als zweiten Sicherheitsfaktor verwenden. 
@@ -29,5 +30,5 @@ Nein. Die Mobile ID-Anwendung wird nicht als zweiter starker Sicherheitsfaktor f
 {{<collapsibleBlock groupId="mobile_id">}}
 Sie können einfach überprüfen, ob Ihre Mobile ID aktiv ist, indem Sie sie auf der Mobile ID-Website testen. Danach können Sie die Schritte befolgen, um sie als zweiten starken Sicherheitsfaktor zu Ihrem CH-LOGIN hinzuzufügen.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/de/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -11,24 +11,33 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 {{<numberedList>}}
-1. Ich habe keine SIM-Karte, die neu genug ist, um die Mobile ID zu nutzen, was kann ich tun?
+{{<listItem>}}
+Ich habe keine SIM-Karte, die neu genug ist, um die Mobile ID zu nutzen, was kann ich tun?
 {{<collapsibleBlock groupId="mobile_id">}}
 Sie können bei Ihrem Telefonanbieter eine SIM-Karte der neuesten Generation bestellen. Sie können auch einen FIDO-Schlüssel als zweiten Sicherheitsfaktor verwenden. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Was tun Sie, wenn das mit der Mobile ID verbundene Mobiltelefon gestohlen wird/verloren geht?
+{{<listItem>}}
+Was tun Sie, wenn das mit der Mobile ID verbundene Mobiltelefon gestohlen wird/verloren geht?
 {{<collapsibleBlock groupId="mobile_id">}}
 Lassen Sie Ihre SIM-Karte von Ihrem Mobilfunkanbieter sperren. Dadurch wird Ihre Mobile ID automatisch gesperrt. Sobald Sie eine neue SIM-Karte haben, können Sie Ihre Mobile ID bei Ihrem Netzbetreiber mithilfe des Reaktivierungscodes, den Sie bei der Aktivierung Ihrer Mobile ID erhalten haben, erneut aktivieren. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Kann ich die Mobile ID-Anwendung anstelle der Aktivierung mit der SIM-Karte verwenden?
+{{<listItem>}}
+Kann ich die Mobile ID-Anwendung anstelle der Aktivierung mit der SIM-Karte verwenden?
 {{<collapsibleBlock groupId="mobile_id">}}
 Nein. Die Mobile ID-Anwendung wird nicht als zweiter starker Sicherheitsfaktor für Ihr CH-LOGIN akzeptiert. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ich habe bereits eine aktive Mobile ID, was muss ich tun?
+{{<listItem>}}
+Ich habe bereits eine aktive Mobile ID, was muss ich tun?
 {{<collapsibleBlock groupId="mobile_id">}}
 Sie können einfach überprüfen, ob Ihre Mobile ID aktiv ist, indem Sie sie auf der Mobile ID-Website testen. Danach können Sie die Schritte befolgen, um sie als zweiten starken Sicherheitsfaktor zu Ihrem CH-LOGIN hinzuzufügen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/de/FAQ/Onboarding_eIAM/4_zugang.md
@@ -11,24 +11,33 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="zugang">}}
 
 {{<numberedList>}}
-1. Läuft der Onboarding-Code nach einer bestimmten Zeit ab? Wenn ja, was soll ich tun, wenn ich mich nicht rechtzeitig anmelden konnte? 
+{{<listItem>}}
+Läuft der Onboarding-Code nach einer bestimmten Zeit ab? Wenn ja, was soll ich tun, wenn ich mich nicht rechtzeitig anmelden konnte? 
 {{<collapsibleBlock groupId="zugang">}}
 Der Onboarding-Code läuft nach einem Monat ab. Wenn Sie nach dieser Frist noch keine Zeit für das Onboarding hatten, wenden Sie sich bitte an Ihren KT_SuperUser, damit er Ihnen einen Code zurückschickt. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Was muss ich tun, wenn ich nicht mehr im Krankenhaus arbeite? Kann ich mein Profil löschen?
+{{<listItem>}}
+Was muss ich tun, wenn ich nicht mehr im Krankenhaus arbeite? Kann ich mein Profil löschen?
 {{<collapsibleBlock groupId="zugang">}}
 Wenn Sie aufgrund eines Mitarbeiterwechsels keinen Zugang zur SpiGes-Plattform mehr benötigen oder eine Änderung der Rolle/des Zugangs notwendig ist, müssen Sie sich zwingend bei der zuständigen Person in Ihrem Kanton melden, damit diese Ihnen die Zugänge zur SpiGes-Plattform entziehen kann. Ihr CH-LOGIN-Konto und der zweite verifizierte starke Faktor sind persönlich, können für andere Anwendungen der Bundesverwaltung verwendet werden und müssen nicht gelöscht werden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. An wen kann ich mich wenden, wenn mein Login nicht funktioniert?
+{{<listItem>}}
+An wen kann ich mich wenden, wenn mein Login nicht funktioniert?
 {{<collapsibleBlock groupId="zugang">}}
 Ihr erster Ansprechpartner ist immer der Verantwortliche Ihres Kantons. Wenn Sie gemeinsam keine Lösung für Ihr Problem finden, können Sie sich anschliessend an das BFS wenden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ich habe einen anderen Kontotyp der Bundesverwaltung, kann dieser verwendet werden? 
+{{<listItem>}}
+Ich habe einen anderen Kontotyp der Bundesverwaltung, kann dieser verwendet werden? 
 {{<collapsibleBlock groupId="zugang">}}
 Nein, es wird leider nicht möglich sein, andere elektronische Identitäten als die dargestellte zu verwenden. Dies liegt daran, dass andere elektronische Identitäten keine ausreichende Authentifizierungsqualität für die Nutzung von SpiGes aufweisen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/de/FAQ/Onboarding_eIAM/4_zugang.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="zugang">}}
 
 1. Läuft der Onboarding-Code nach einer bestimmten Zeit ab? Wenn ja, was soll ich tun, wenn ich mich nicht rechtzeitig anmelden konnte? 
@@ -28,3 +29,5 @@ Ihr erster Ansprechpartner ist immer der Verantwortliche Ihres Kantons. Wenn Sie
 {{<collapsibleBlock groupId="zugang">}}
 Nein, es wird leider nicht möglich sein, andere elektronische Identitäten als die dargestellte zu verwenden. Dies liegt daran, dass andere elektronische Identitäten keine ausreichende Authentifizierungsqualität für die Nutzung von SpiGes aufweisen.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/de/FAQ/Onboarding_eIAM/4_zugang.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="zugang">}}
 
+{{<numberedList>}}
 1. Läuft der Onboarding-Code nach einer bestimmten Zeit ab? Wenn ja, was soll ich tun, wenn ich mich nicht rechtzeitig anmelden konnte? 
 {{<collapsibleBlock groupId="zugang">}}
 Der Onboarding-Code läuft nach einem Monat ab. Wenn Sie nach dieser Frist noch keine Zeit für das Onboarding hatten, wenden Sie sich bitte an Ihren KT_SuperUser, damit er Ihnen einen Code zurückschickt. 
@@ -29,5 +30,5 @@ Ihr erster Ansprechpartner ist immer der Verantwortliche Ihres Kantons. Wenn Sie
 {{<collapsibleBlock groupId="zugang">}}
 Nein, es wird leider nicht möglich sein, andere elektronische Identitäten als die dargestellte zu verwenden. Dies liegt daran, dass andere elektronische Identitäten keine ausreichende Authentifizierungsqualität für die Nutzung von SpiGes aufweisen.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -58,6 +58,7 @@ Die Pilotspitäler werden bereits im Frühjahr 2024 einen ersten «Datensatz» e
 {{</listItem>}}
 
 {{<listItem>}}
+{{<markdown>}}
 Vertauschte Werte: Uns ist aufgefallen, dass bei ein paar Variablen die Werte anders gegenüber der MS-Statistik sind. Als Beispiel gibt es hier den Vitalwert.       
 MS-Statistik:       
 0 = totgeboren      
@@ -66,6 +67,7 @@ Spiges (genau andersrum):
 0 = Lebendgeburt        
 1 = Totgeburt 		
 Andere Beispiele wären hier die Schulbildung oder der Zivilstand. Das ist aus unserer Sicht nicht optimal und wir würden gerne wissen, ob dies beabsichtigt ist, und wenn ja, warum? 
+{{</markdown>}}
 {{<collapsibleBlock groupId="anpassungen">}}
 Das ist beabsichtigt. Im Sinne des once only haben wir die Codelisten und Metadaten in ein BFS System integriert, welches dann auch veröffentlicht wird. Die neuen Codelisten entsprechen jetzt dem schweizweiten Standard der Interoperabilitätsplattform i14y.admin.ch, vorher war es eine MS Sonderlösung.
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,25 +11,16 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="anpassungen">}}
 
 1. Welche Variablen ändern sich mit SpiGes?
 {{<collapsibleBlock groupId="anpassungen">}}
-<ul>
-<li> SpiGes hat vor allem grössere Auswirkungen auf den Prozess der Datenprüfung und das Datenformat der Lieferung. Bei den medizinischen Angaben (heutige MS) ändern sich nur wenige Punkte. Die wichtigsten dürften für Sie die folgenden sein:
-<ul>
-<li>	Die Hauptbehandlung wird abgeschafft. </li>
-<li>	Der Zusatz zur Hauptdiagnose wird abgeschafft. </li>
-<li>	Diagnosen und Behandlungen können neu in unbegrenzter Zahl erfasst werden. </li>
-<li>	Die chirurgische Leistungszeit wird bei operativen Prozeduren erfasst. </li>
-<li>	Der Behandlungsbeginn muss bei operativen Prozeduren mit der Uhrzeit (der Operation insgesamt) erfasst werden.  </li>
-<li>	Der Bezug zwischen mehreren Diagnosen (Kreuz/Stern, Ausrufezeichen) wird neu mit einer Bezugsvariable (diagnose_zusatz) anstelle des Sonderzeichens erfasst. </li>
-</ul>
-</li>
-
-<li> Alle Änderungen am Datensatz sowie die genauen Details können Sie am besten nachvollziehen, wenn Sie die Variablenliste zur Hand nehmen und die Spalte «Neu/MS-Variable» filtern nach neuen und angepassten Variablen. </li>
-
-<li> Neu werden Rechnungsdaten und Kosten, resp. Erlöse pro Fall erhoben. </li>
-
-<li> Hier finden Sie den kompletten Datensatz:  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
-</li>
-</ul>
+- SpiGes hat vor allem grössere Auswirkungen auf den Prozess der Datenprüfung und das Datenformat der Lieferung. Bei den medizinischen Angaben (heutige MS) ändern sich nur wenige Punkte. Die wichtigsten dürften für Sie die folgenden sein:
+	- Die Hauptbehandlung wird abgeschafft. 
+	- Der Zusatz zur Hauptdiagnose wird abgeschafft. 
+	- Diagnosen und Behandlungen können neu in unbegrenzter Zahl erfasst werden. 
+	- Die chirurgische Leistungszeit wird bei operativen Prozeduren erfasst. 
+	- Der Behandlungsbeginn muss bei operativen Prozeduren mit der Uhrzeit (der Operation insgesamt) erfasst werden.  
+	- Der Bezug zwischen mehreren Diagnosen (Kreuz/Stern, Ausrufezeichen) wird neu mit einer Bezugsvariable (diagnose_zusatz) anstelle des Sonderzeichens erfasst. 
+- Alle Änderungen am Datensatz sowie die genauen Details können Sie am besten nachvollziehen, wenn Sie die Variablenliste zur Hand nehmen und die Spalte «Neu/MS-Variable» filtern nach neuen und angepassten Variablen. 
+- Neu werden Rechnungsdaten und Kosten, resp. Erlöse pro Fall erhoben. 
+- Hier finden Sie den kompletten Datensatz:  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
 {{</collapsibleBlock>}}
 
 2. Welche Auswirkungen hat SpiGes auf die Kodierrichtlinien?
@@ -44,11 +35,10 @@ Der genaue Inhalt des Prüfprotokolls hängt von den Prüfungen ab, welche aktue
 
 4. Die Pilotspitäler werden bereits im Frühjahr 2024 einen ersten «Datensatz» erstellen können. Andere Kantone stellen die Anforderung, bis September ein erstes XML-Datenfile abzugeben. Werden bei diesen Abgaben Echtdaten aus einem Produktivsystem erwartet, oder reichen Testdaten aus einem Testsystem aus? Anders gefragt: Beginnt die «richtige» Auswertung erst mit dem Jahre 2025, oder will das BFS auch schon Echtdaten aus 2024 auswerten?
 {{<collapsibleBlock groupId="anpassungen">}}
-<ul>
-<li>	Für den Pilot im Frühjahr 2024 werden von den Pilotspitälern Echtdaten aus einem Produktivsystem erwartet. Diese werden nur analysiert, um Erkenntnisse über den Pilot zu gewinnen. </li>
-<li>	Per August 2024 müssen alle Spitäler (in allen Kantonen) einen Schnittstellentest durchführen, um zu zeigen, dass die technische Umsetzung der Schnittstelle funktioniert. Dafür genügen Teillieferungen auch aus Testsystemen. </li>
-<li>	Ab dem 1.1. 2025 müssen alle Spitäler Echtdaten des Jahres 2024 aus den Produktivsystemen liefern und diese bis Ende April vollständig prüfen und ggf. begründen. </li>
-</ul>
+- Für den Pilot im Frühjahr 2024 werden von den Pilotspitälern Echtdaten aus einem Produktivsystem erwartet. Diese werden nur analysiert, um Erkenntnisse über den Pilot zu gewinnen. 
+- Per August 2024 müssen alle Spitäler (in allen Kantonen) einen Schnittstellentest durchführen, um zu zeigen, dass die technische Umsetzung der Schnittstelle funktioniert. Dafür genügen Teillieferungen auch aus Testsystemen. 
+- Ab dem 1.1. 2025 müssen alle Spitäler Echtdaten des Jahres 2024 aus den Produktivsystemen liefern und diese bis Ende April vollständig prüfen und ggf. begründen. 
+
 {{</collapsibleBlock>}}
 
 5. Vertauschte Werte: Uns ist aufgefallen, dass bei ein paar Variablen die Werte anders gegenüber der MS-Statistik sind. Als Beispiel gibt es hier den Vitalwert.       

--- a/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -6,11 +6,16 @@ weight: 20
 type: docs
 keywords: []
 ---
+{{<faqBlock>}}
 
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="anpassungen">}}
 
-1. Welche Variablen ändern sich mit SpiGes?
+{{<numberedList>}}
+
+{{<listItem>}}
+Welche Variablen ändern sich mit SpiGes?
 {{<collapsibleBlock groupId="anpassungen">}}
+{{<markdown>}}
 - SpiGes hat vor allem grössere Auswirkungen auf den Prozess der Datenprüfung und das Datenformat der Lieferung. Bei den medizinischen Angaben (heutige MS) ändern sich nur wenige Punkte. Die wichtigsten dürften für Sie die folgenden sein:
 	- Die Hauptbehandlung wird abgeschafft. 
 	- Der Zusatz zur Hauptdiagnose wird abgeschafft. 
@@ -20,27 +25,40 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="anpassungen">}}
 	- Der Bezug zwischen mehreren Diagnosen (Kreuz/Stern, Ausrufezeichen) wird neu mit einer Bezugsvariable (diagnose_zusatz) anstelle des Sonderzeichens erfasst. 
 - Alle Änderungen am Datensatz sowie die genauen Details können Sie am besten nachvollziehen, wenn Sie die Variablenliste zur Hand nehmen und die Spalte «Neu/MS-Variable» filtern nach neuen und angepassten Variablen. 
 - Neu werden Rechnungsdaten und Kosten, resp. Erlöse pro Fall erhoben. 
-- Hier finden Sie den kompletten Datensatz:  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
+- Hier finden Sie den kompletten Datensatz: [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Welche Auswirkungen hat SpiGes auf die Kodierrichtlinien?
+{{<listItem>}}
+Welche Auswirkungen hat SpiGes auf die Kodierrichtlinien?
 {{<collapsibleBlock groupId="anpassungen">}}
-Diese Informationen finden Sie im Kodierungshandbuch. Dieses ist unter dem folgenden Link herunterladbar: <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html </a>
+{{<markdown>}}
+Diese Informationen finden Sie im Kodierungshandbuch. Dieses ist unter dem folgenden Link herunterladbar: [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Was ist der Inhalt des nationalen Prüfprotokolls?
+{{<listItem>}}
+Was ist der Inhalt des nationalen Prüfprotokolls?
 {{<collapsibleBlock groupId="anpassungen">}}
 Der genaue Inhalt des Prüfprotokolls hängt von den Prüfungen ab, welche aktuell mit einer Arbeitsgruppe mit allen Stakeholdern erarbeitet werden. Im Wesentlichen umfasst das Prüfprotokoll die Prüfungen, welche angeschlagen haben sowie die offiziellen Begründungen zu diesen Prüfungen (ein Auszug aus dem Chat zur Prüfung).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Die Pilotspitäler werden bereits im Frühjahr 2024 einen ersten «Datensatz» erstellen können. Andere Kantone stellen die Anforderung, bis September ein erstes XML-Datenfile abzugeben. Werden bei diesen Abgaben Echtdaten aus einem Produktivsystem erwartet, oder reichen Testdaten aus einem Testsystem aus? Anders gefragt: Beginnt die «richtige» Auswertung erst mit dem Jahre 2025, oder will das BFS auch schon Echtdaten aus 2024 auswerten?
+{{<listItem>}}
+Die Pilotspitäler werden bereits im Frühjahr 2024 einen ersten «Datensatz» erstellen können. Andere Kantone stellen die Anforderung, bis September ein erstes XML-Datenfile abzugeben. Werden bei diesen Abgaben Echtdaten aus einem Produktivsystem erwartet, oder reichen Testdaten aus einem Testsystem aus? Anders gefragt: Beginnt die «richtige» Auswertung erst mit dem Jahre 2025, oder will das BFS auch schon Echtdaten aus 2024 auswerten?
 {{<collapsibleBlock groupId="anpassungen">}}
+{{<markdown>}}
 - Für den Pilot im Frühjahr 2024 werden von den Pilotspitälern Echtdaten aus einem Produktivsystem erwartet. Diese werden nur analysiert, um Erkenntnisse über den Pilot zu gewinnen. 
 - Per August 2024 müssen alle Spitäler (in allen Kantonen) einen Schnittstellentest durchführen, um zu zeigen, dass die technische Umsetzung der Schnittstelle funktioniert. Dafür genügen Teillieferungen auch aus Testsystemen. 
 - Ab dem 1.1. 2025 müssen alle Spitäler Echtdaten des Jahres 2024 aus den Produktivsystemen liefern und diese bis Ende April vollständig prüfen und ggf. begründen. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Vertauschte Werte: Uns ist aufgefallen, dass bei ein paar Variablen die Werte anders gegenüber der MS-Statistik sind. Als Beispiel gibt es hier den Vitalwert.       
+{{<listItem>}}
+Vertauschte Werte: Uns ist aufgefallen, dass bei ein paar Variablen die Werte anders gegenüber der MS-Statistik sind. Als Beispiel gibt es hier den Vitalwert.       
 MS-Statistik:       
 0 = totgeboren      
 1 = lebendgeboren       
@@ -51,9 +69,14 @@ Andere Beispiele wären hier die Schulbildung oder der Zivilstand. Das ist aus u
 {{<collapsibleBlock groupId="anpassungen">}}
 Das ist beabsichtigt. Im Sinne des once only haben wir die Codelisten und Metadaten in ein BFS System integriert, welches dann auch veröffentlicht wird. Die neuen Codelisten entsprechen jetzt dem schweizweiten Standard der Interoperabilitätsplattform i14y.admin.ch, vorher war es eine MS Sonderlösung.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Berechnete Werte: In der Variablenliste gibt es einige Zeilen die «ausgegraut» sind mit der Bemerkung «berechnet» (Beispiel uid). Heisst das, wir liefern sie im XML leer mit und das BFS wird diese berechnen und eintragen? Oder liefern wir diese Werte gar nicht mit und ignorieren sie? 
+{{<listItem>}}
+Berechnete Werte: In der Variablenliste gibt es einige Zeilen die «ausgegraut» sind mit der Bemerkung «berechnet» (Beispiel uid). Heisst das, wir liefern sie im XML leer mit und das BFS wird diese berechnen und eintragen? Oder liefern wir diese Werte gar nicht mit und ignorieren sie? 
 {{<collapsibleBlock groupId="anpassungen">}}
 Wie Sie dem XML Schema entnehmen können, sind diese berechneten Variablen nicht enthalten. Sie können diese ignorieren.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+{{</numberedList>}}
 
+{{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/de/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -38,7 +38,6 @@ Der genaue Inhalt des Prüfprotokolls hängt von den Prüfungen ab, welche aktue
 - Für den Pilot im Frühjahr 2024 werden von den Pilotspitälern Echtdaten aus einem Produktivsystem erwartet. Diese werden nur analysiert, um Erkenntnisse über den Pilot zu gewinnen. 
 - Per August 2024 müssen alle Spitäler (in allen Kantonen) einen Schnittstellentest durchführen, um zu zeigen, dass die technische Umsetzung der Schnittstelle funktioniert. Dafür genügen Teillieferungen auch aus Testsystemen. 
 - Ab dem 1.1. 2025 müssen alle Spitäler Echtdaten des Jahres 2024 aus den Produktivsystemen liefern und diese bis Ende April vollständig prüfen und ggf. begründen. 
-
 {{</collapsibleBlock>}}
 
 5. Vertauschte Werte: Uns ist aufgefallen, dass bei ein paar Variablen die Werte anders gegenüber der MS-Statistik sind. Als Beispiel gibt es hier den Vitalwert.       
@@ -47,8 +46,7 @@ MS-Statistik:
 1 = lebendgeboren       
 Spiges (genau andersrum):              
 0 = Lebendgeburt        
-1 = Totgeburt 
-
+1 = Totgeburt 		
 Andere Beispiele wären hier die Schulbildung oder der Zivilstand. Das ist aus unserer Sicht nicht optimal und wir würden gerne wissen, ob dies beabsichtigt ist, und wenn ja, warum? 
 {{<collapsibleBlock groupId="anpassungen">}}
 Das ist beabsichtigt. Im Sinne des once only haben wir die Codelisten und Metadaten in ein BFS System integriert, welches dann auch veröffentlicht wird. Die neuen Codelisten entsprechen jetzt dem schweizweiten Standard der Interoperabilitätsplattform i14y.admin.ch, vorher war es eine MS Sonderlösung.

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -21,7 +21,7 @@ Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundg
 {{</collapsibleBlock>}}
 {{</listItem>}}
 
-{{</listItem>}}
+{{<listItem>}}
 Was ist der Unterschied zwischen einem Spitalunternehmen, einem Spital und einem Spitalstandort?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -61,8 +61,7 @@ Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitäler
 Eine Leistungsstelle ist eine organisatorische Einheit im Spital, in der u.a. medizinische, medizinisch-technische oder medizinisch-therapeutische Leistungen erbracht werden. In der SpiGes Erhebung wird angegeben, in welcher medizinischen Hauptleistungsstelle der Patient behandelt wird. 
 {{</collapsibleBlock>}}
 
- 6.	Wenn ein Spital mehrere Standorte hat, wird ein Fall immer nur an einem Standort erfasst, auch wenn er von einem Standort zu einem anderen Standort desselben Spitals verlegt wurde?
-
- {{<collapsibleBlock groupID="GGH">}}
+6.	Wenn ein Spital mehrere Standorte hat, wird ein Fall immer nur an einem Standort erfasst, auch wenn er von einem Standort zu einem anderen Standort desselben Spitals verlegt wurde?
+{{<collapsibleBlock groupID="GGH">}}
 Ja, ein Fall wird immer nur an einem Standort erfasst und zwar am Hauptstandort (vgl. variable burnr). 
 {{</collapsibleBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,16 +11,18 @@ keywords: []
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="GGH">}}
 
 {{<numberedList>}}
-
-1. Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
+{{<listItem>}}
+Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Bei der ersten SpiGes Erhebung (Daten 2024) im Jahre 2025 wird noch manuell die Grundgesamtheit KS in Form von Excellisten importiert.
 - Die bisherige BUR wird BURGESV heissen und der Identifikator des Spitals bleiben. Die Standort-BUR heisst ab den Daten 2024 (Erhebung 2025) BUR.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Was ist der Unterschied zwischen einem Spitalunternehmen, einem Spital und einem Spitalstandort?
+{{</listItem>}}
+Was ist der Unterschied zwischen einem Spitalunternehmen, einem Spital und einem Spitalstandort?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Ein Spitalunternehmen, ist ein Unternehmen mit dem NOGA-Code 861001 (Allgemeine Krankenhäuser), 861002 (Spezialkliniken) oder 869004 (Geburtshäuser). Es ist mit der Identifikationsnummer ENTID eindeutig bezeichnet.
@@ -30,8 +32,10 @@ Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitäler
 {{</markdown>}}
 {{<insertImage image="tableauFAQ1.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Welche Begriffe werden in der SpiGes Erhebung synonym für Spitalunternehmen, Spital und Spitalstandort verwendet?
+{{<listItem>}}
+Welche Begriffe werden in der SpiGes Erhebung synonym für Spitalunternehmen, Spital und Spitalstandort verwendet?
 {{<collapsibleBlock groupId="GGH">}}
 <table class="w-100">
   <tr>
@@ -56,24 +60,31 @@ Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitäler
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Wie wird festgestellt, zu welchem Spital (burnr_gesv) ein Standort (burnr) gehört?
+{{<listItem>}}
+Wie wird festgestellt, zu welchem Spital (burnr_gesv) ein Standort (burnr) gehört?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Die Zuordnung der Standorte (BUR-Nummern) zu den Spitälern (BUR-GESV) erfragen wir bei der Erhebung der Grundgesamtheit. In diesem Prozess sind es die Kantone, die uns in Zusammenarbeit mit den Krankenhäusern die Informationen geben.
 - Die burnr_gesv wird auf Wunsch unserer Partner auch erhoben.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Was versteht man unter einer Hauptleistungsstelle (z.B. M000, M050)?
+{{<listItem>}}
+Was versteht man unter einer Hauptleistungsstelle (z.B. M000, M050)?
 {{<collapsibleBlock groupId="GGH">}}
 Eine Leistungsstelle ist eine organisatorische Einheit im Spital, in der u.a. medizinische, medizinisch-technische oder medizinisch-therapeutische Leistungen erbracht werden. In der SpiGes Erhebung wird angegeben, in welcher medizinischen Hauptleistungsstelle der Patient behandelt wird. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6.	Wenn ein Spital mehrere Standorte hat, wird ein Fall immer nur an einem Standort erfasst, auch wenn er von einem Standort zu einem anderen Standort desselben Spitals verlegt wurde?
+{{<listItem>}}
+Wenn ein Spital mehrere Standorte hat, wird ein Fall immer nur an einem Standort erfasst, auch wenn er von einem Standort zu einem anderen Standort desselben Spitals verlegt wurde?
 {{<collapsibleBlock groupID="GGH">}}
 Ja, ein Fall wird immer nur an einem Standort erfasst und zwar am Hauptstandort (vgl. variable burnr). 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -12,16 +12,20 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Bei der ersten SpiGes Erhebung (Daten 2024) im Jahre 2025 wird noch manuell die Grundgesamtheit KS in Form von Excellisten importiert.
 - Die bisherige BUR wird BURGESV heissen und der Identifikator des Spitals bleiben. Die Standort-BUR heisst ab den Daten 2024 (Erhebung 2025) BUR.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Was ist der Unterschied zwischen einem Spitalunternehmen, einem Spital und einem Spitalstandort?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Ein Spitalunternehmen, ist ein Unternehmen mit dem NOGA-Code 861001 (Allgemeine Krankenhäuser), 861002 (Spezialkliniken) oder 869004 (Geburtshäuser). Es ist mit der Identifikationsnummer ENTID eindeutig bezeichnet.
 - Das Spital ist in der SpiGes Erhebung eine Einheit, welche ein ITAR-K ausfüllt und nach der sich die Falldefinition der SwissDRG AG richtet. Ein Spital ist mit der BUR-Nr. GESV gekennzeichnet, welche nur auf der Datenbank von GESV geführt wird.
 - Ein Spitalstandort ist mit der BUR-Nr. eindeutig gekennzeichnet und gehört immer zu genau einem Spitalunternehmen.
 Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitälern (BURGESV) und 14 Standorten (BUR) :
+{{</markdown>}}
 {{<insertImage image="tableauFAQ1.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
 
@@ -53,8 +57,10 @@ Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitäler
 
 4. Wie wird festgestellt, zu welchem Spital (burnr_gesv) ein Standort (burnr) gehört?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Die Zuordnung der Standorte (BUR-Nummern) zu den Spitälern (BUR-GESV) erfragen wir bei der Erhebung der Grundgesamtheit. In diesem Prozess sind es die Kantone, die uns in Zusammenarbeit mit den Krankenhäusern die Informationen geben.
 - Die burnr_gesv wird auf Wunsch unserer Partner auch erhoben.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. Was versteht man unter einer Hauptleistungsstelle (z.B. M000, M050)?

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -10,6 +10,8 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="GGH">}}
 
+{{<numberedList>}}
+
 1. Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
@@ -73,4 +75,5 @@ Eine Leistungsstelle ist eine organisatorische Einheit im Spital, in der u.a. me
 Ja, ein Fall wird immer nur an einem Standort erfasst und zwar am Hauptstandort (vgl. variable burnr). 
 {{</collapsibleBlock>}}
 
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,19 +11,15 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li>	Bei der ersten SpiGes Erhebung (Daten 2024) im Jahre 2025 wird noch manuell die Grundgesamtheit KS in Form von Excellisten importiert. </li>
-<li>	Die bisherige BUR wird BURGESV heissen und der Identifikator des Spitals bleiben. Die Standort-BUR heisst ab den Daten 2024 (Erhebung 2025) BUR. </li>
-</ul>
+- Bei der ersten SpiGes Erhebung (Daten 2024) im Jahre 2025 wird noch manuell die Grundgesamtheit KS in Form von Excellisten importiert.
+- Die bisherige BUR wird BURGESV heissen und der Identifikator des Spitals bleiben. Die Standort-BUR heisst ab den Daten 2024 (Erhebung 2025) BUR.
 {{</collapsibleBlock>}}
 
 2. Was ist der Unterschied zwischen einem Spitalunternehmen, einem Spital und einem Spitalstandort?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li>	Ein Spitalunternehmen, ist ein Unternehmen mit dem NOGA-Code 861001 (Allgemeine Krankenhäuser), 861002 (Spezialkliniken) oder 869004 (Geburtshäuser). Es ist mit der Identifikationsnummer ENTID eindeutig bezeichnet. </li>
-<li>	Das Spital ist in der SpiGes Erhebung eine Einheit, welche ein ITAR-K ausfüllt und nach der sich die Falldefinition der SwissDRG AG richtet. Ein Spital ist mit der BUR-Nr. GESV gekennzeichnet, welche nur auf der Datenbank von GESV geführt wird. </li>
-<li>	Ein Spitalstandort ist mit der BUR-Nr. eindeutig gekennzeichnet und gehört immer zu genau einem Spitalunternehmen. </li>
-</ul>
+- Ein Spitalunternehmen, ist ein Unternehmen mit dem NOGA-Code 861001 (Allgemeine Krankenhäuser), 861002 (Spezialkliniken) oder 869004 (Geburtshäuser). Es ist mit der Identifikationsnummer ENTID eindeutig bezeichnet.
+- Das Spital ist in der SpiGes Erhebung eine Einheit, welche ein ITAR-K ausfüllt und nach der sich die Falldefinition der SwissDRG AG richtet. Ein Spital ist mit der BUR-Nr. GESV gekennzeichnet, welche nur auf der Datenbank von GESV geführt wird.
+- Ein Spitalstandort ist mit der BUR-Nr. eindeutig gekennzeichnet und gehört immer zu genau einem Spitalunternehmen.
 Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitälern (BURGESV) und 14 Standorten (BUR) :
 {{<insertImage image="tableauFAQ1.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
@@ -56,10 +52,8 @@ Folgende Tabelle zeigt als Beispiel ein Unternehmen (UID/ENTID) mit 12 Spitäler
 
 4. Wie wird festgestellt, zu welchem Spital (burnr_gesv) ein Standort (burnr) gehört?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li>	Die Zuordnung der Standorte (BUR-Nummern) zu den Spitälern (BUR-GESV) erfragen wir bei der Erhebung der Grundgesamtheit. In diesem Prozess sind es die Kantone, die uns in Zusammenarbeit mit den Krankenhäusern die Informationen geben. </li>
-<li>	Die burnr_gesv wird auf Wunsch unserer Partner auch erhoben. </li>
-</ul>
+- Die Zuordnung der Standorte (BUR-Nummern) zu den Spitälern (BUR-GESV) erfragen wir bei der Erhebung der Grundgesamtheit. In diesem Prozess sind es die Kantone, die uns in Zusammenarbeit mit den Krankenhäusern die Informationen geben.
+- Die burnr_gesv wird auf Wunsch unserer Partner auch erhoben.
 {{</collapsibleBlock>}}
 
 5. Was versteht man unter einer Hauptleistungsstelle (z.B. M000, M050)?

--- a/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/de/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Wird bei der Einführung von SpiGes bzw. zum Zeitpunkt der Definition der Grundgesamtheit für die erste SpiGes-Erhebung noch mit den herkömmlichen «Spitallisten» oder bereits mit SpiReg gearbeitet?
@@ -65,3 +66,5 @@ Eine Leistungsstelle ist eine organisatorische Einheit im Spital, in der u.a. me
 {{<collapsibleBlock groupID="GGH">}}
 Ja, ein Fall wird immer nur an einem Standort erfasst und zwar am Hauptstandort (vgl. variable burnr). 
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
  
+{{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 1. SpiGes erhebt nur Informationen zu den stationären Fällen. Wie kann der ambulante Teil des ITAR_K ausgefüllt werden?
@@ -40,3 +41,5 @@ Bei dieser Frist müssen die Kostendaten erstmals automatisch auf der SpiGes Pla
 {{<collapsibleBlock groupId="ITARK">}}
 Das zentrale Instrument für Tarifierung und Wirtschaftlichkeitsprüfung soll in Zukunft durch SpiGes erstellt werden. Um einen sicheren Übergang sowie die Korrektheit zu gewährleisten, ist ein Parallelbetrieb der alten und neuen Plattform (H+ resp. SpiGes) zur Erstellung von ITAR_K® vorgesehen. Im Jahr 2025 (Daten 2024) werden die offiziellen ITAR_K® noch wie bisher von der H+-Plattform erstellt. Ab September 2025 erhalten alle Spitäler zudem die Möglichkeit, die ITAR_K® 2025 (Daten 2024) über SpiGes zu erstellen und die beiden Resultate zu vergleichen. So können allfällige Unklarheiten noch vor der produktiven Einführung der ITAR_K® -Erstellung über SpiGes im Jahr 2026 (Daten 2025) ausgeräumt werden.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -27,14 +27,18 @@ Bei dieser Frist müssen die Kostendaten erstmals automatisch auf der SpiGes Pla
 
 4. Wir finden keine SpiGes-Variable, die es ermöglichen würde, die direkt mit einem Fall verbundenen GWL-Einnahmen/Kosten in die dafür vorgesehene GWL Spalte im ITAR_K zu überführen. Wie wird die GWL-Spalte von ITAR_K mit den SpiGes Daten berechnet?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 -	Bei der Abbildung der gemeinwirtschaftlichen Leistungen hält sich SpiGes grundsätzlich an die Rechtsprechung und die Empfehlungen des Spitalverbandes H+. REKOLE® sieht vor, dass die Kosten der fallbezogenen gemeinwirtschaftlichen Leistungen auf dem Fall, die Erlöse jedoch auf einem separaten GWL-Kostenträger abgebildet werden. Kosten und Erlöse von fallunabhängigen GWL werden ebenfalls auf einem separaten GWL-Kostenträger abgebildet.
 -	Aus technischer Sicht ist es möglich, von den Vorgaben von REKOLE® abzuweichen. Die Kosten und Erlöse der fallbezogenen GWL könnten auch auf einem eigenen Kostenträger (Typ KTR 700-799) erfasst werden. Dies liegt im Ermessen des Kantons. Wichtig ist in diesem Fall, dass die Kosten und Erlöse für die OKP-Leistungen trotzdem auf dem Fall erfasst werden (Typ KTR = 1).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. ITAR_K kann sowohl auf Unternehmens als auch auf Standort-Ebene ausgefüllt werden. Was wird in SpiGes verlangt? Liegt die Entscheidung dazu bei den Kantonen?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 -	ITAR_K wird immer auf der Ebene BUR-GESV ausgefüllt, diese Ebene muss mit der Erhebung der KS übereinstimmen. Die Informationen dazu liefert der Kanton in der Erhebung der Grundgesamtheit an das BFS. Insofern hat der Kanton einen Einfluss. Er muss sich aber mit dem Spital absprechen.
 -	Das ITAR_K stellt das Grundinstrument für die Verhandlungen der Spitäler mit den Versicherern dar. Ob dabei der Kanton bezüglich Granularität mitbestimmt, ist abhängig davon ob es sich um ein Listenspital, ein Vertragsspital oder ein Ausstandspital handelt.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 6. Ab wann wird das ITAR_K® ab der SpiGes Plattform generiert werden?

--- a/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -12,41 +12,53 @@ Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 {{<numberedList>}}
 
-1. SpiGes erhebt nur Informationen zu den stationären Fällen. Wie kann der ambulante Teil des ITAR_K ausgefüllt werden?
+{{<listItem>}}
+SpiGes erhebt nur Informationen zu den stationären Fällen. Wie kann der ambulante Teil des ITAR_K ausgefüllt werden?
 {{<collapsibleBlock groupId="ITARK">}}
 Das ITAR_K kann mit den SpiGes Daten erstellt werden. Die ambulanten Angaben werden in den dafür vorgesehenen KTR Typen erhoben (z.B. Tarif Labor).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Wie wird das ITAR_K von Kliniken erstellt, welche nur Teil eines Spitalunternehmens sind? (z.B. Klinik St. Anne von Fribourg ist Teil der Swiss Medical Network AG)
+{{<listItem>}}
+Wie wird das ITAR_K von Kliniken erstellt, welche nur Teil eines Spitalunternehmens sind? (z.B. Klinik St. Anne von Fribourg ist Teil der Swiss Medical Network AG)
 {{<collapsibleBlock groupId="ITARK">}}
 Die Klinik St. Anne von Fribourg wird die Finanzbuchhaltung (und alle anderen Angaben) in der Krankenhausstatistik pro Klinik (Ebene BURGESV) ausfüllen. Die Kosten aus SpiGes lassen sich nach BURGESV aggregieren.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Die Kostendaten muss man bis zum 31.3 erfassen. Müssen diese Daten revidiert sein? Aktuell könnten wir das nicht umsetzen da der Jahresabschluss erst Ende März revidiert wird.
+{{<listItem>}}
+Die Kostendaten muss man bis zum 31.3 erfassen. Müssen diese Daten revidiert sein? Aktuell könnten wir das nicht umsetzen da der Jahresabschluss erst Ende März revidiert wird.
 {{<collapsibleBlock groupId="ITARK">}}
 Bei dieser Frist müssen die Kostendaten erstmals automatisch auf der SpiGes Plattform geprüft sein. Die Revision kann später erfolgen.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Wir finden keine SpiGes-Variable, die es ermöglichen würde, die direkt mit einem Fall verbundenen GWL-Einnahmen/Kosten in die dafür vorgesehene GWL Spalte im ITAR_K zu überführen. Wie wird die GWL-Spalte von ITAR_K mit den SpiGes Daten berechnet?
+{{<listItem>}}
+Wir finden keine SpiGes-Variable, die es ermöglichen würde, die direkt mit einem Fall verbundenen GWL-Einnahmen/Kosten in die dafür vorgesehene GWL Spalte im ITAR_K zu überführen. Wie wird die GWL-Spalte von ITAR_K mit den SpiGes Daten berechnet?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 -	Bei der Abbildung der gemeinwirtschaftlichen Leistungen hält sich SpiGes grundsätzlich an die Rechtsprechung und die Empfehlungen des Spitalverbandes H+. REKOLE® sieht vor, dass die Kosten der fallbezogenen gemeinwirtschaftlichen Leistungen auf dem Fall, die Erlöse jedoch auf einem separaten GWL-Kostenträger abgebildet werden. Kosten und Erlöse von fallunabhängigen GWL werden ebenfalls auf einem separaten GWL-Kostenträger abgebildet.
 -	Aus technischer Sicht ist es möglich, von den Vorgaben von REKOLE® abzuweichen. Die Kosten und Erlöse der fallbezogenen GWL könnten auch auf einem eigenen Kostenträger (Typ KTR 700-799) erfasst werden. Dies liegt im Ermessen des Kantons. Wichtig ist in diesem Fall, dass die Kosten und Erlöse für die OKP-Leistungen trotzdem auf dem Fall erfasst werden (Typ KTR = 1).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. ITAR_K kann sowohl auf Unternehmens als auch auf Standort-Ebene ausgefüllt werden. Was wird in SpiGes verlangt? Liegt die Entscheidung dazu bei den Kantonen?
+{{<listItem>}}
+ITAR_K kann sowohl auf Unternehmens als auch auf Standort-Ebene ausgefüllt werden. Was wird in SpiGes verlangt? Liegt die Entscheidung dazu bei den Kantonen?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 -	ITAR_K wird immer auf der Ebene BUR-GESV ausgefüllt, diese Ebene muss mit der Erhebung der KS übereinstimmen. Die Informationen dazu liefert der Kanton in der Erhebung der Grundgesamtheit an das BFS. Insofern hat der Kanton einen Einfluss. Er muss sich aber mit dem Spital absprechen.
 -	Das ITAR_K stellt das Grundinstrument für die Verhandlungen der Spitäler mit den Versicherern dar. Ob dabei der Kanton bezüglich Granularität mitbestimmt, ist abhängig davon ob es sich um ein Listenspital, ein Vertragsspital oder ein Ausstandspital handelt.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Ab wann wird das ITAR_K® ab der SpiGes Plattform generiert werden?
+{{<listItem>}}
+Ab wann wird das ITAR_K® ab der SpiGes Plattform generiert werden?
 {{<collapsibleBlock groupId="ITARK">}}
 Das zentrale Instrument für Tarifierung und Wirtschaftlichkeitsprüfung soll in Zukunft durch SpiGes erstellt werden. Um einen sicheren Übergang sowie die Korrektheit zu gewährleisten, ist ein Parallelbetrieb der alten und neuen Plattform (H+ resp. SpiGes) zur Erstellung von ITAR_K® vorgesehen. Im Jahr 2025 (Daten 2024) werden die offiziellen ITAR_K® noch wie bisher von der H+-Plattform erstellt. Ab September 2025 erhalten alle Spitäler zudem die Möglichkeit, die ITAR_K® 2025 (Daten 2024) über SpiGes zu erstellen und die beiden Resultate zu vergleichen. So können allfällige Unklarheiten noch vor der produktiven Einführung der ITAR_K® -Erstellung über SpiGes im Jahr 2026 (Daten 2025) ausgeräumt werden.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -26,18 +26,14 @@ Bei dieser Frist müssen die Kostendaten erstmals automatisch auf der SpiGes Pla
 
 4. Wir finden keine SpiGes-Variable, die es ermöglichen würde, die direkt mit einem Fall verbundenen GWL-Einnahmen/Kosten in die dafür vorgesehene GWL Spalte im ITAR_K zu überführen. Wie wird die GWL-Spalte von ITAR_K mit den SpiGes Daten berechnet?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li>	Bei der Abbildung der gemeinwirtschaftlichen Leistungen hält sich SpiGes grundsätzlich an die Rechtsprechung und die Empfehlungen des Spitalverbandes H+. REKOLE® sieht vor, dass die Kosten der fallbezogenen gemeinwirtschaftlichen Leistungen auf dem Fall, die Erlöse jedoch auf einem separaten GWL-Kostenträger abgebildet werden. Kosten und Erlöse von fallunabhängigen GWL werden ebenfalls auf einem separaten GWL-Kostenträger abgebildet. </li>
-<li>	Aus technischer Sicht ist es möglich, von den Vorgaben von REKOLE® abzuweichen. Die Kosten und Erlöse der fallbezogenen GWL könnten auch auf einem eigenen Kostenträger (Typ KTR 700-799) erfasst werden. Dies liegt im Ermessen des Kantons. Wichtig ist in diesem Fall, dass die Kosten und Erlöse für die OKP-Leistungen trotzdem auf dem Fall erfasst werden (Typ KTR = 1). </li>
-</ul>
+-	Bei der Abbildung der gemeinwirtschaftlichen Leistungen hält sich SpiGes grundsätzlich an die Rechtsprechung und die Empfehlungen des Spitalverbandes H+. REKOLE® sieht vor, dass die Kosten der fallbezogenen gemeinwirtschaftlichen Leistungen auf dem Fall, die Erlöse jedoch auf einem separaten GWL-Kostenträger abgebildet werden. Kosten und Erlöse von fallunabhängigen GWL werden ebenfalls auf einem separaten GWL-Kostenträger abgebildet.
+-	Aus technischer Sicht ist es möglich, von den Vorgaben von REKOLE® abzuweichen. Die Kosten und Erlöse der fallbezogenen GWL könnten auch auf einem eigenen Kostenträger (Typ KTR 700-799) erfasst werden. Dies liegt im Ermessen des Kantons. Wichtig ist in diesem Fall, dass die Kosten und Erlöse für die OKP-Leistungen trotzdem auf dem Fall erfasst werden (Typ KTR = 1).
 {{</collapsibleBlock>}}
 
 5. ITAR_K kann sowohl auf Unternehmens als auch auf Standort-Ebene ausgefüllt werden. Was wird in SpiGes verlangt? Liegt die Entscheidung dazu bei den Kantonen?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li>	ITAR_K wird immer auf der Ebene BUR-GESV ausgefüllt, diese Ebene muss mit der Erhebung der KS übereinstimmen. Die Informationen dazu liefert der Kanton in der Erhebung der Grundgesamtheit an das BFS. Insofern hat der Kanton einen Einfluss. Er muss sich aber mit dem Spital absprechen. </li>
-<li>	Das ITAR_K stellt das Grundinstrument für die Verhandlungen der Spitäler mit den Versicherern dar. Ob dabei der Kanton bezüglich Granularität mitbestimmt, ist abhängig davon ob es sich um ein Listenspital, ein Vertragsspital oder ein Ausstandspital handelt. </li>
-</ul>
+-	ITAR_K wird immer auf der Ebene BUR-GESV ausgefüllt, diese Ebene muss mit der Erhebung der KS übereinstimmen. Die Informationen dazu liefert der Kanton in der Erhebung der Grundgesamtheit an das BFS. Insofern hat der Kanton einen Einfluss. Er muss sich aber mit dem Spital absprechen.
+-	Das ITAR_K stellt das Grundinstrument für die Verhandlungen der Spitäler mit den Versicherern dar. Ob dabei der Kanton bezüglich Granularität mitbestimmt, ist abhängig davon ob es sich um ein Listenspital, ein Vertragsspital oder ein Ausstandspital handelt.
 {{</collapsibleBlock>}}
 
 6. Ab wann wird das ITAR_K® ab der SpiGes Plattform generiert werden?

--- a/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/de/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -10,6 +10,8 @@ keywords: []
 {{<faqBlock>}}
 Um alle Fragen zu öffnen: {{<collapsibleGroupCommand groupId="ITARK">}}
 
+{{<numberedList>}}
+
 1. SpiGes erhebt nur Informationen zu den stationären Fällen. Wie kann der ambulante Teil des ITAR_K ausgefüllt werden?
 {{<collapsibleBlock groupId="ITARK">}}
 Das ITAR_K kann mit den SpiGes Daten erstellt werden. Die ambulanten Angaben werden in den dafür vorgesehenen KTR Typen erhoben (z.B. Tarif Labor).
@@ -46,4 +48,5 @@ Bei dieser Frist müssen die Kostendaten erstmals automatisch auf der SpiGes Pla
 Das zentrale Instrument für Tarifierung und Wirtschaftlichkeitsprüfung soll in Zukunft durch SpiGes erstellt werden. Um einen sicheren Übergang sowie die Korrektheit zu gewährleisten, ist ein Parallelbetrieb der alten und neuen Plattform (H+ resp. SpiGes) zur Erstellung von ITAR_K® vorgesehen. Im Jahr 2025 (Daten 2024) werden die offiziellen ITAR_K® noch wie bisher von der H+-Plattform erstellt. Ab September 2025 erhalten alle Spitäler zudem die Möglichkeit, die ITAR_K® 2025 (Daten 2024) über SpiGes zu erstellen und die beiden Resultate zu vergleichen. So können allfällige Unklarheiten noch vor der produktiven Einführung der ITAR_K® -Erstellung über SpiGes im Jahr 2026 (Daten 2025) ausgeräumt werden.
 {{</collapsibleBlock>}}
 
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/de/eIAM_Onboarding/_index.md
+++ b/content/de/eIAM_Onboarding/_index.md
@@ -48,9 +48,9 @@ Beispiel:
 <div class="left_col">
 <!-- First column content goes here -->
 <p> <ol>
-  <li> In dieser Spalte sehen Sie die EntID auf Unternehmensebene und Sie sehen die Bur-Nummer auf Ebene der Krankenhausstandorte. </li>
-  <li> In dieser Spalte sehen Sie den "administrativen" Kanton des Unternehmens / des Krankenhausstandorts. </li>
-  <li> In dieser Spalte sehen Sie den geografischen Kanton des Unternehmens / des Krankenhausstandorts. </li>
+  - In dieser Spalte sehen Sie die EntID auf Unternehmensebene und Sie sehen die Bur-Nummer auf Ebene der Krankenhausstandorte. 
+  - In dieser Spalte sehen Sie den "administrativen" Kanton des Unternehmens / des Krankenhausstandorts. 
+  - In dieser Spalte sehen Sie den geografischen Kanton des Unternehmens / des Krankenhausstandorts. 
 </ol> </p>
 
 <p> Hier sehen Sie, dass der administrative und der geografische Kanton von Standort 1 nicht identisch sind.  </p>

--- a/content/fr/FAQ/2_identifikatoren.md
+++ b/content/fr/FAQ/2_identifikatoren.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 1. Le numéro AVS est un champ obligatoire. Malgré tout, il y aura des cas sans numéro AVS. Où est décrit ce qui doit être mis dans la variable dans ce cas ?
@@ -23,3 +24,4 @@ Lors de la transmission des données, les identifiants et les données sont envo
 {{<collapsibleBlock groupId="identifikatoren">}}
 Le canton peut exporter des données pendant l'enquête à des fins de plausibilisation, le NAVS sera alors pseudonymisé.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/2_identifikatoren.md
+++ b/content/fr/FAQ/2_identifikatoren.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
+{{<numberedList>}}
 1. Le numéro AVS est un champ obligatoire. Malgré tout, il y aura des cas sans numéro AVS. Où est décrit ce qui doit être mis dans la variable dans ce cas ?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Précisément cette question est encore ouverte. Dans la description des variables, on peut lire : «Remarque : en ce qui concerne les personnes qui ne peuvent pas avoir de numéro AVS, des clarifications sont encore en cours (voir aussi la colonne "A indiquer pour")». A court terme, il est envisagé de laisser la variable vide dans ce cas ou d'indiquer un numéro fictif. Mais certains cantons frontaliers se sont fortement opposés à cette idée, raison pour laquelle cette question sera encore clarifiée plus en détail à long terme.
@@ -24,4 +25,5 @@ Lors de la transmission des données, les identifiants et les données sont envo
 {{<collapsibleBlock groupId="identifikatoren">}}
 Le canton peut exporter des données pendant l'enquête à des fins de plausibilisation, le NAVS sera alors pseudonymisé.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/2_identifikatoren.md
+++ b/content/fr/FAQ/2_identifikatoren.md
@@ -11,19 +11,26 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 {{<numberedList>}}
-1. Le numéro AVS est un champ obligatoire. Malgré tout, il y aura des cas sans numéro AVS. Où est décrit ce qui doit être mis dans la variable dans ce cas ?
+{{<listItem>}}
+Le numéro AVS est un champ obligatoire. Malgré tout, il y aura des cas sans numéro AVS. Où est décrit ce qui doit être mis dans la variable dans ce cas ?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Précisément cette question est encore ouverte. Dans la description des variables, on peut lire : «Remarque : en ce qui concerne les personnes qui ne peuvent pas avoir de numéro AVS, des clarifications sont encore en cours (voir aussi la colonne "A indiquer pour")». A court terme, il est envisagé de laisser la variable vide dans ce cas ou d'indiquer un numéro fictif. Mais certains cantons frontaliers se sont fortement opposés à cette idée, raison pour laquelle cette question sera encore clarifiée plus en détail à long terme.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Le numéro AVS doit être utilisé pour la collecte des données. Le numéro AVS sera-t-il également visible pour les caisses maladie via les partenaires tarifaires ?
+{{<listItem>}}
+Le numéro AVS doit être utilisé pour la collecte des données. Le numéro AVS sera-t-il également visible pour les caisses maladie via les partenaires tarifaires ?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Lors de la transmission des données, les identifiants et les données sont envoyés séparément. Le canal de données est crypté. L'OFS utilise un validateur pour vérifier le numéro AVS. Une fois que le numéro AVS a été crypté, il est enregistré dans la base de données sécurisée des identifiants. Pendant le traitement des données sur la plateforme, le numéro AVS est ainsi pseudonymisé et n'est pas stocké avec l'ensemble des données de prestations. Le numéro AVS ne peut être transmis aux utilisateurs de données que sous forme cryptée. Comme ces utilisateurs de données ne connaissent pas la clé, le numéro AVS est anonymisé pour eux. Il n'est pas possible d'en déduire la valeur originale.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Le canton a-t-il accès au fichier ID des livraisons ?
+{{<listItem>}}
+Le canton a-t-il accès au fichier ID des livraisons ?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Le canton peut exporter des données pendant l'enquête à des fins de plausibilisation, le NAVS sera alors pseudonymisé.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
+{{<numberedList>}}
 1. Comment saisir les coûts et les revenus des prestations d'intérêt général dans SpiGes ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Pour ce faire, il suffit de sélectionner sous ktr_typ le code de la prestation PIG correspondante et de saisir les coûts et les revenus correspondants à l'aide des numéros de charge par nature ou de centre de charges et des comptes de revenus définis dans REKOLE®®. Ci-dessous vous trouvez la liste des différents types de PIG et le code ktr_typ correspondant :
@@ -116,5 +117,5 @@ Oui, c'est possible. Une unité finale d’imputation est attribuée à une colo
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Pour pouvoir remplir ITAR_K®, les coûts des cas ambulatoires sont remplis sommairement par type de CUFI (p. ex. Tarif Dialyse).
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 1. Comment saisir les coûts et les revenus des prestations d'intérêt général dans SpiGes ?
@@ -115,3 +116,5 @@ Oui, c'est possible. Une unité finale d’imputation est attribuée à une colo
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Pour pouvoir remplir ITAR_K®, les coûts des cas ambulatoires sont remplis sommairement par type de CUFI (p. ex. Tarif Dialyse).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/fr/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -11,7 +11,8 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 {{<numberedList>}}
-1. Comment saisir les coûts et les revenus des prestations d'intérêt général dans SpiGes ?
+{{<listItem>}}
+Comment saisir les coûts et les revenus des prestations d'intérêt général dans SpiGes ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Pour ce faire, il suffit de sélectionner sous ktr_typ le code de la prestation PIG correspondante et de saisir les coûts et les revenus correspondants à l'aide des numéros de charge par nature ou de centre de charges et des comptes de revenus définis dans REKOLE®®. Ci-dessous vous trouvez la liste des différents types de PIG et le code ktr_typ correspondant :
 <table class="w-100">
@@ -102,20 +103,28 @@ Pour ce faire, il suffit de sélectionner sous ktr_typ le code de la prestation 
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Les objets de coûts non reliés à un cas peuvent-ils être rattachés à un hôpital (burnr_gesv) au lieu d'un site ? 
+{{<listItem>}}
+Les objets de coûts non reliés à un cas peuvent-ils être rattachés à un hôpital (burnr_gesv) au lieu d'un site ? 
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Non, ce n'est pas possible. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Peut-on utiliser les types KTR plusieurs fois ? Par exemple, pour 599, livrer plusieurs lignes avec un texte libre différent dans la variable «ktr_beschr» ?
+{{<listItem>}}
+Peut-on utiliser les types KTR plusieurs fois ? Par exemple, pour 599, livrer plusieurs lignes avec un texte libre différent dans la variable «ktr_beschr» ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Oui, c'est possible. Une unité finale d’imputation est attribuée à une colonne ITAR_K® sur la base de l'indication «ktr_typ». Ainsi, une des valeurs prédéfinies doit être utilisée dans la variable «ktr_typ». Il est toutefois possible d'indiquer plusieurs unités finales d’imputation avec le même type de KTR, par exemple pour le ktr_typ 205, une fois avec le texte libre «LAMal» et une fois avec le texte libre «CTM» dans la variable «ktr_beschr». Ces deux objets de coûts sont ensuite additionnés et représentés dans la colonne ITAR_K® «Psy. Hôpital de jour enfants, adolescents». En théorie, d'autres déclinaisons sont techniquement possibles, jusqu’au cas ambulatoire. Tant qu'ils présentent tous le même type KTR, ils sont additionnés et représentés comme décrit.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. La partie CUFI est-elle également attendue pour les cas ambulatoires ou se rapporte-t-elle également exclusivement aux cas hospitaliers ?
+{{<listItem>}}
+La partie CUFI est-elle également attendue pour les cas ambulatoires ou se rapporte-t-elle également exclusivement aux cas hospitaliers ?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Pour pouvoir remplir ITAR_K®, les coûts des cas ambulatoires sont remplis sommairement par type de CUFI (p. ex. Tarif Dialyse).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
+{{<numberedList>}}
 1. Je connais la comptabilité des ajustements dans SDEP. Est-ce qu'elle existera aussi dans SpiGes ou seulement selon ITAR_K® ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes utilise la passerelle d’ajustement de la CDS / de REKOLE®.
@@ -72,5 +73,5 @@ Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspon
 De plus amples informations sont disponibles dans le manuel REKOLE® (chapitre 6.5.3).
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -27,9 +27,7 @@ Dans la comptabilité par unité finale d'imputation de SpiGes, il est possible 
 4. Pour 2024 (données 2023), SwissDRG a demandé le détail des coûts d’utilisation des immobilisations des cas selon OCP. Dans SpiGes, les variables "_ank" permettent d’envoyer le détail des coûts d’utilisation des immobilisations des cas selon REKOLE®.
 Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoir dans SpiGes les variables "_ank" pour les résultats OCP également ? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-
 - Il ne s'agit que d'un relevé test de SwissDRG SA. Si le passage définitif à OCP devait avoir lieu, les coûts d'utilisation des immobilisations par centre de charges dans SpiGes seraient livrés selon OCP au lieu de REKOLE® et les coûts d'utilisation des immobilisations REKOLE® seraient relevés sous forme de somme. 
-
 - En résumé, les coûts d’utilisation des immobilisations doivent être représentés selon les méthodes suivantes :
 <table class="w-100">
   <tr>
@@ -60,10 +58,7 @@ Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoi
     <td> REKOLE® </td>
   </tr>
 </table>
-
-
 {{</collapsibleBlock>}}
-
 5. Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspondent aux charges par nature suivante : 

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 1. Je connais la comptabilité des ajustements dans SDEP. Est-ce qu'elle existera aussi dans SpiGes ou seulement selon ITAR_K® ?
@@ -67,3 +68,5 @@ Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspon
 - 448 Charges des intérêts calculés sur les actifs immobilisés 
 De plus amples informations sont disponibles dans le manuel REKOLE® (chapitre 6.5.3).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -11,22 +11,29 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 {{<numberedList>}}
-1. Je connais la comptabilité des ajustements dans SDEP. Est-ce qu'elle existera aussi dans SpiGes ou seulement selon ITAR_K® ?
+{{<listItem>}}
+Je connais la comptabilité des ajustements dans SDEP. Est-ce qu'elle existera aussi dans SpiGes ou seulement selon ITAR_K® ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes utilise la passerelle d’ajustement de la CDS / de REKOLE®.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Où les justifications des délimitations sont-elles intégrées dans l'OFS ? Ou comment dois-je comprendre cela ?
+{{<listItem>}}
+Où les justifications des délimitations sont-elles intégrées dans l'OFS ? Ou comment dois-je comprendre cela ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Les justifications sont saisies en tant que contrôles dans SpiGes. Cela signifie que si un montant de la comptabilité financière et de la comptabilité analytique ne concorde pas, la différence doit être justifiée. Ces justifications sont ensuite utilisées, par exemple pour le rapport national de vérification et pour ITAR_K®, ou encore pour la passerelle d’ajustement de la CDS.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Où sont pris en compte les coûts des séjours à cheval dans la passerelle d’ajustement ?  
+{{<listItem>}}
+Où sont pris en compte les coûts des séjours à cheval dans la passerelle d’ajustement ?  
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Dans la comptabilité par unité finale d'imputation de SpiGes, il est possible de calculer les coûts des patients sortis au cours de l'année (cas A). Ces coûts seront donc calculés par l’OFS. Ceux-ci peuvent déjà être entrés à l'hôpital l'année précédente et avoir généré des coûts. Dans la comptabilité financière, les charges sont saisies par année (calcul périodique). La différence qui en résulte est corrigée dans la passerelle d’ajustement de SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Pour 2024 (données 2023), SwissDRG a demandé le détail des coûts d’utilisation des immobilisations des cas selon OCP. Dans SpiGes, les variables "_ank" permettent d’envoyer le détail des coûts d’utilisation des immobilisations des cas selon REKOLE®.
+{{<listItem>}}
+Pour 2024 (données 2023), SwissDRG a demandé le détail des coûts d’utilisation des immobilisations des cas selon OCP. Dans SpiGes, les variables "_ank" permettent d’envoyer le détail des coûts d’utilisation des immobilisations des cas selon REKOLE®.
 Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoir dans SpiGes les variables "_ank" pour les résultats OCP également ? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
@@ -63,7 +70,10 @@ Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoi
   </tr>
 </table>
 {{</collapsibleBlock>}}
-5. Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?
+{{</listItem>}}
+
+{{<listItem>}}
+Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspondent aux charges par nature suivante : 
@@ -73,5 +83,7 @@ Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspon
 De plus amples informations sont disponibles dans le manuel REKOLE® (chapitre 6.5.3).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -28,8 +28,10 @@ Dans la comptabilité par unité finale d'imputation de SpiGes, il est possible 
 4. Pour 2024 (données 2023), SwissDRG a demandé le détail des coûts d’utilisation des immobilisations des cas selon OCP. Dans SpiGes, les variables "_ank" permettent d’envoyer le détail des coûts d’utilisation des immobilisations des cas selon REKOLE®.
 Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoir dans SpiGes les variables "_ank" pour les résultats OCP également ? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
+{{<markdown>}}
 - Il ne s'agit que d'un relevé test de SwissDRG SA. Si le passage définitif à OCP devait avoir lieu, les coûts d'utilisation des immobilisations par centre de charges dans SpiGes seraient livrés selon OCP au lieu de REKOLE® et les coûts d'utilisation des immobilisations REKOLE® seraient relevés sous forme de somme. 
 - En résumé, les coûts d’utilisation des immobilisations doivent être représentés selon les méthodes suivantes :
+{{</markdown>}}
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variables </div></th>
@@ -62,11 +64,13 @@ Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoi
 {{</collapsibleBlock>}}
 5. Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
+{{<markdown>}}
 Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspondent aux charges par nature suivante : 
 - 442 Amortissements 
 - 444 Autres loyers (y compris leasing opérationnel) 
 - 448 Charges des intérêts calculés sur les actifs immobilisés 
 De plus amples informations sont disponibles dans le manuel REKOLE® (chapitre 6.5.3).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -66,9 +66,9 @@ Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoi
 
 5. Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspondent aux charges par nature suivante : <br />
-- 442 Amortissements <br />
-- 444 Autres loyers (y compris leasing opérationnel) <br />
-- 448 Charges des intérêts calculés sur les actifs immobilisés <br />
+Les coûts d’utilisation des immobilisations (selon REKOLE® et OCP) correspondent aux charges par nature suivante : 
+- 442 Amortissements 
+- 444 Autres loyers (y compris leasing opérationnel) 
+- 448 Charges des intérêts calculés sur les actifs immobilisés 
 De plus amples informations sont disponibles dans le manuel REKOLE® (chapitre 6.5.3).
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/5_abstimmungsbrucke.md
+++ b/content/fr/FAQ/5_abstimmungsbrucke.md
@@ -27,10 +27,10 @@ Dans la comptabilité par unité finale d'imputation de SpiGes, il est possible 
 4. Pour 2024 (données 2023), SwissDRG a demandé le détail des coûts d’utilisation des immobilisations des cas selon OCP. Dans SpiGes, les variables "_ank" permettent d’envoyer le détail des coûts d’utilisation des immobilisations des cas selon REKOLE®.
 Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoir dans SpiGes les variables "_ank" pour les résultats OCP également ? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-<ul>
-<li> Il ne s'agit que d'un relevé test de SwissDRG SA. Si le passage définitif à OCP devait avoir lieu, les coûts d'utilisation des immobilisations par centre de charges dans SpiGes seraient livrés selon OCP au lieu de REKOLE® et les coûts d'utilisation des immobilisations REKOLE® seraient relevés sous forme de somme. </li>
 
-<li> En résumé, les coûts d’utilisation des immobilisations doivent être représentés selon les méthodes suivantes :
+- Il ne s'agit que d'un relevé test de SwissDRG SA. Si le passage définitif à OCP devait avoir lieu, les coûts d'utilisation des immobilisations par centre de charges dans SpiGes seraient livrés selon OCP au lieu de REKOLE® et les coûts d'utilisation des immobilisations REKOLE® seraient relevés sous forme de somme. 
+
+- En résumé, les coûts d’utilisation des immobilisations doivent être représentés selon les méthodes suivantes :
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variables </div></th>
@@ -60,8 +60,8 @@ Ce détail étant maintenant nécessaire à SwissDRG, ne faudrait-il pas prévoi
     <td> REKOLE® </td>
   </tr>
 </table>
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 5. Le compte 441 ne rentre dans aucun calcul des coûts d’utilisation des immobilisations, ni selon OCP, ni selon REKOLE®. Pouvez-vous confirmer cela ?

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -73,7 +73,9 @@ En janvier 2023, nous avons organisé une réunion d'information à l’intentio
 </table>
 Est-il possible de livrer ces tableaux sous forme de fichiers xml individuels à la plateforme SpiGes ?
 {{<collapsibleBlock groupId="technische_fragen">}}
-Le tableau 12 Identificateurs de personnes doit être livré dans un fichier séparé (pour des raisons de protection des données). Pour les autres tableaux, un autre fichier est défini, mais il supporte les livraisons partielles. En théorie, il est donc possible de livrer tous les tableaux dans un seul fichier XML sous forme de livraisons partielles. Nous ne le recommandons toutefois pas, car cela nécessite une coordination complexe des différents tableaux (s'assurer que les informations sur tous les cas sont disponibles dans tous les fichiers).  Vous trouverez des informations plus précises à ce sujet dans la description du fichier XML pour l'importation de données dans la plateforme SpiGes sur notre site web.  <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a>
+{{<markdown>}}
+Le tableau 12 Identificateurs de personnes doit être livré dans un fichier séparé (pour des raisons de protection des données). Pour les autres tableaux, un autre fichier est défini, mais il supporte les livraisons partielles. En théorie, il est donc possible de livrer tous les tableaux dans un seul fichier XML sous forme de livraisons partielles. Nous ne le recommandons toutefois pas, car cela nécessite une coordination complexe des différents tableaux (s'assurer que les informations sur tous les cas sont disponibles dans tous les fichiers).  Vous trouverez des informations plus précises à ce sujet dans la description du fichier XML pour l'importation de données dans la plateforme SpiGes sur notre site web [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 4. Existe-t-il une possibilité pour les petits établissements de créer un fichier XML à partir d'un fichier Excel (dans lequel la CUFI est saisie). Existe-t-il un fournisseur qui prévoit de le faire ?
@@ -93,8 +95,10 @@ Il y aura plusieurs fichiers d'exportation. D'une part, il sera possible d'expor
 
 7. Dans le format XML, l'ordre des variables au sein d'une ligne joue-t-il un rôle ?
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - L'ordre des éléments est prédéfini et ne peut pas être modifié. Les éléments peuvent tout au plus être omis. Ainsi, pour l'élément «cas», les sous-éléments doivent toujours être indiqués dans l'ordre suivant : «administratif», «nouveau-nés», «psychiatrie», «CUFI cas», «diagnostics», «traitements», «médicaments», «facture», «mouvement des patients» et «données cantonales».  
 - L'ordre des attributs peut en revanche être choisi librement. Ainsi, par exemple, dans l'élément «administratif», il est possible d'indiquer aussi bien «...sexe="2" âge="37"...» que «...âge="37" sexe="2"...». 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 8. Des variables peuvent-elles également manquer sur une ligne si la clinique n'a rien à remplir sur cette ligne pour la variable correspondante ? Ou toutes les variables de l'interface doivent-elles toujours figurer sur chaque ligne ?
@@ -114,10 +118,11 @@ Un outil de contrôle sera mis à disposition via API (Application Programming I
 
 11. Sait-on déjà quelle sera la procédure concernant les données supplémentaires cantonales ? Plusieurs cantons (par ex. LU, GR, VS et VD) disposent déjà d'une ligne MK. En outre, les cantons de ZH et BE collectent également des données supplémentaires dans le cadre du SDEP. Savez-vous déjà si ces données seront intégrées dans l'exportation SpiGes ou si elles devront être exportées séparément ?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
-- Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
+{{<markdown>}}
+- Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html) 
 - Les données cantonales supplémentaires peuvent certes être indiquées dans le XML, mais elles ne sont pas traitées plus avant lors de l'importation sur la plateforme SpiGes. Elles sont plausibilisées et traitées séparément par les cantons. 
 - Les données cantonales ne peuvent être exportées que par l'hôpital lui-même et par le canton. Il est probable que les données cantonales pour ces utilisateurs soient contenues dans le même fichier XML que les autres données.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 12. Est-ce qu’il sera possible d’effectuer des corrections directement sur la plateforme ?
@@ -132,8 +137,10 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 
 14. Nouvelles variables medi_id et rech_id : d'après la description, nous ne savons pas s'il s'agit de numéros d'ordre ou d'ID réels du système. Si oui, lesquelles ? En ce qui concerne medi_id, nous avons tout de suite pensé au code ATC_, mais il existe une variable supplémentaire pour cela. 
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - Il s'agit, pour les deux nouvelles variables "medi_id" et "rech_id", d'identifiants qui sont nécessaires pour des raisons techniques afin d'assurer une attribution claire. Ceux-ci ne doivent pas obligatoirement commencer par 1, mais ils doivent être uniques pour chaque cas. 
 - Le fichier modèle XML 1.3, que vous trouverez sur notre site , contient également un exemple. medi_id ="1" contient l'information selon laquelle il s'agit du premier médicament hautement coûteux selon les directives de SwissDRG SA pour ce cas spécifique. 
+{{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
 

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -92,10 +92,10 @@ Il y aura plusieurs fichiers d'exportation. D'une part, il sera possible d'expor
 
 7. Dans le format XML, l'ordre des variables au sein d'une ligne joue-t-il un rôle ?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> L'ordre des éléments est prédéfini et ne peut pas être modifié. Les éléments peuvent tout au plus être omis. Ainsi, pour l'élément «cas», les sous-éléments doivent toujours être indiqués dans l'ordre suivant : «administratif», «nouveau-nés», «psychiatrie», «CUFI cas», «diagnostics», «traitements», «médicaments», «facture», «mouvement des patients» et «données cantonales».  </li>
-<li> L'ordre des attributs peut en revanche être choisi librement. Ainsi, par exemple, dans l'élément «administratif», il est possible d'indiquer aussi bien «...sexe="2" âge="37"...» que «...âge="37" sexe="2"...». </li>
-</ul>
+
+- L'ordre des éléments est prédéfini et ne peut pas être modifié. Les éléments peuvent tout au plus être omis. Ainsi, pour l'élément «cas», les sous-éléments doivent toujours être indiqués dans l'ordre suivant : «administratif», «nouveau-nés», «psychiatrie», «CUFI cas», «diagnostics», «traitements», «médicaments», «facture», «mouvement des patients» et «données cantonales».  
+- L'ordre des attributs peut en revanche être choisi librement. Ainsi, par exemple, dans l'élément «administratif», il est possible d'indiquer aussi bien «...sexe="2" âge="37"...» que «...âge="37" sexe="2"...». 
+
 {{</collapsibleBlock>}}
 
 8. Des variables peuvent-elles également manquer sur une ligne si la clinique n'a rien à remplir sur cette ligne pour la variable correspondante ? Ou toutes les variables de l'interface doivent-elles toujours figurer sur chaque ligne ?
@@ -115,11 +115,11 @@ Un outil de contrôle sera mis à disposition via API (Application Programming I
 
 11. Sait-on déjà quelle sera la procédure concernant les données supplémentaires cantonales ? Plusieurs cantons (par ex. LU, GR, VS et VD) disposent déjà d'une ligne MK. En outre, les cantons de ZH et BE collectent également des données supplémentaires dans le cadre du SDEP. Savez-vous déjà si ces données seront intégrées dans l'exportation SpiGes ou si elles devront être exportées séparément ?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> </li>
-<li> Les données cantonales supplémentaires peuvent certes être indiquées dans le XML, mais elles ne sont pas traitées plus avant lors de l'importation sur la plateforme SpiGes. Elles sont plausibilisées et traitées séparément par les cantons. </li>
-<li> Les données cantonales ne peuvent être exportées que par l'hôpital lui-même et par le canton. Il est probable que les données cantonales pour ces utilisateurs soient contenues dans le même fichier XML que les autres données.</li>
-</ul> 
+
+- Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
+- Les données cantonales supplémentaires peuvent certes être indiquées dans le XML, mais elles ne sont pas traitées plus avant lors de l'importation sur la plateforme SpiGes. Elles sont plausibilisées et traitées séparément par les cantons. 
+- Les données cantonales ne peuvent être exportées que par l'hôpital lui-même et par le canton. Il est probable que les données cantonales pour ces utilisateurs soient contenues dans le même fichier XML que les autres données.
+ 
 {{</collapsibleBlock>}}
 
 12. Est-ce qu’il sera possible d’effectuer des corrections directement sur la plateforme ?
@@ -134,12 +134,12 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 
 14. Nouvelles variables medi_id et rech_id : d'après la description, nous ne savons pas s'il s'agit de numéros d'ordre ou d'ID réels du système. Si oui, lesquelles ? En ce qui concerne medi_id, nous avons tout de suite pensé au code ATC_, mais il existe une variable supplémentaire pour cela. 
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Il s'agit, pour les deux nouvelles variables "medi_id" et "rech_id", d'identifiants qui sont nécessaires pour des raisons techniques afin d'assurer une attribution claire. Ceux-ci ne doivent pas obligatoirement commencer par 1, mais ils doivent être uniques pour chaque cas. </li>
-<li> Le fichier modèle XML 1.3, que vous trouverez sur notre site , contient également un exemple. medi_id ="1" contient l'information selon laquelle il s'agit du premier médicament hautement coûteux selon les directives de SwissDRG SA pour ce cas spécifique. 
+
+- Il s'agit, pour les deux nouvelles variables "medi_id" et "rech_id", d'identifiants qui sont nécessaires pour des raisons techniques afin d'assurer une attribution claire. Ceux-ci ne doivent pas obligatoirement commencer par 1, mais ils doivent être uniques pour chaque cas. 
+- Le fichier modèle XML 1.3, que vous trouverez sur notre site , contient également un exemple. medi_id ="1" contient l'information selon laquelle il s'agit du premier médicament hautement coûteux selon les directives de SwissDRG SA pour ce cas spécifique. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 15.	Dans les fichiers d'exemple pour le fichier des identificateurs et le fichier des données, il y a deux champs pour la version. Or, ces versions ne correspondent pas. Ainsi, la version 1.0 est indiquée dans l'en-tête et la version 1.3 dans le tag Entreprise. Pourquoi les numéros de version sont-ils différents ? Comment savoir quand indiquer quel numéro de version ?

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -92,10 +92,8 @@ Il y aura plusieurs fichiers d'exportation. D'une part, il sera possible d'expor
 
 7. Dans le format XML, l'ordre des variables au sein d'une ligne joue-t-il un rôle ?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - L'ordre des éléments est prédéfini et ne peut pas être modifié. Les éléments peuvent tout au plus être omis. Ainsi, pour l'élément «cas», les sous-éléments doivent toujours être indiqués dans l'ordre suivant : «administratif», «nouveau-nés», «psychiatrie», «CUFI cas», «diagnostics», «traitements», «médicaments», «facture», «mouvement des patients» et «données cantonales».  
 - L'ordre des attributs peut en revanche être choisi librement. Ainsi, par exemple, dans l'élément «administratif», il est possible d'indiquer aussi bien «...sexe="2" âge="37"...» que «...âge="37" sexe="2"...». 
-
 {{</collapsibleBlock>}}
 
 8. Des variables peuvent-elles également manquer sur une ligne si la clinique n'a rien à remplir sur cette ligne pour la variable correspondante ? Ou toutes les variables de l'interface doivent-elles toujours figurer sur chaque ligne ?
@@ -119,7 +117,6 @@ Un outil de contrôle sera mis à disposition via API (Application Programming I
 - Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
 - Les données cantonales supplémentaires peuvent certes être indiquées dans le XML, mais elles ne sont pas traitées plus avant lors de l'importation sur la plateforme SpiGes. Elles sont plausibilisées et traitées séparément par les cantons. 
 - Les données cantonales ne peuvent être exportées que par l'hôpital lui-même et par le canton. Il est probable que les données cantonales pour ces utilisateurs soient contenues dans le même fichier XML que les autres données.
- 
 {{</collapsibleBlock>}}
 
 12. Est-ce qu’il sera possible d’effectuer des corrections directement sur la plateforme ?
@@ -134,12 +131,9 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 
 14. Nouvelles variables medi_id et rech_id : d'après la description, nous ne savons pas s'il s'agit de numéros d'ordre ou d'ID réels du système. Si oui, lesquelles ? En ce qui concerne medi_id, nous avons tout de suite pensé au code ATC_, mais il existe une variable supplémentaire pour cela. 
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - Il s'agit, pour les deux nouvelles variables "medi_id" et "rech_id", d'identifiants qui sont nécessaires pour des raisons techniques afin d'assurer une attribution claire. Ceux-ci ne doivent pas obligatoirement commencer par 1, mais ils doivent être uniques pour chaque cas. 
 - Le fichier modèle XML 1.3, que vous trouverez sur notre site , contient également un exemple. medi_id ="1" contient l'information selon laquelle il s'agit du premier médicament hautement coûteux selon les directives de SwissDRG SA pour ce cas spécifique. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-
-
 {{</collapsibleBlock>}}
 
 15.	Dans les fichiers d'exemple pour le fichier des identificateurs et le fichier des données, il y a deux champs pour la version. Or, ces versions ne correspondent pas. Ainsi, la version 1.0 est indiquée dans l'en-tête et la version 1.3 dans le tag Entreprise. Pourquoi les numéros de version sont-ils différents ? Comment savoir quand indiquer quel numéro de version ?

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
+{{<numberedList>}}
 1. Existe-t-il un modèle de format pour l'importation de données dans l'application SpiGes ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Oui, les formats du concept d'interface doivent être repris. 
@@ -149,5 +150,5 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" se trouve toujours ainsi . La version supérieure se réfère donc au "XML" lui-même, et la version inférieure au XML SpiGes spécifique.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -11,17 +11,22 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 {{<numberedList>}}
-1. Existe-t-il un modèle de format pour l'importation de données dans l'application SpiGes ?
+{{<listItem>}}
+Existe-t-il un modèle de format pour l'importation de données dans l'application SpiGes ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Oui, les formats du concept d'interface doivent être repris. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Les grands fournisseurs de logiciels d’administration des patients (par exemple SAP) ont-ils également été informés par l'OFS et développent-ils déjà des solutions logicielles ? Il est probable que le fichier XML devrait à l'avenir être créé dans le logiciel d’administration des patients.
+{{<listItem>}}
+Les grands fournisseurs de logiciels d’administration des patients (par exemple SAP) ont-ils également été informés par l'OFS et développent-ils déjà des solutions logicielles ? Il est probable que le fichier XML devrait à l'avenir être créé dans le logiciel d’administration des patients.
 {{<collapsibleBlock groupId="technische_fragen">}}
 En janvier 2023, nous avons organisé une réunion d'information à l’intention des fabricants de systèmes d’information clinique (logiciels d'administration des patients). SAP y était également représenté. L'OFS informe régulièrement ce groupe de l'état d'avancement de SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3.	Selon la liste de variables 1.3, il existe les tableaux suivants 
+{{<listItem>}}
+Selon la liste de variables 1.3, il existe les tableaux suivants 
 <table>
   <tr>
     <td> 1 </td>
@@ -78,46 +83,63 @@ Est-il possible de livrer ces tableaux sous forme de fichiers xml individuels à
 Le tableau 12 Identificateurs de personnes doit être livré dans un fichier séparé (pour des raisons de protection des données). Pour les autres tableaux, un autre fichier est défini, mais il supporte les livraisons partielles. En théorie, il est donc possible de livrer tous les tableaux dans un seul fichier XML sous forme de livraisons partielles. Nous ne le recommandons toutefois pas, car cela nécessite une coordination complexe des différents tableaux (s'assurer que les informations sur tous les cas sont disponibles dans tous les fichiers).  Vous trouverez des informations plus précises à ce sujet dans la description du fichier XML pour l'importation de données dans la plateforme SpiGes sur notre site web [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Existe-t-il une possibilité pour les petits établissements de créer un fichier XML à partir d'un fichier Excel (dans lequel la CUFI est saisie). Existe-t-il un fournisseur qui prévoit de le faire ?
+
+{{<listItem>}}
+Existe-t-il une possibilité pour les petits établissements de créer un fichier XML à partir d'un fichier Excel (dans lequel la CUFI est saisie). Existe-t-il un fournisseur qui prévoit de le faire ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Cette possibilité est actuellement examinée par l'OFS.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Est-il prévu de mettre à disposition un Excel pour les coûts non reliés à un cas, dans lequel établissement peut remplir les coûts non reliés à un cas en format Excel et les exporter ensuite en format XML ? 
+{{<listItem>}}
+Est-il prévu de mettre à disposition un Excel pour les coûts non reliés à un cas, dans lequel établissement peut remplir les coûts non reliés à un cas en format Excel et les exporter ensuite en format XML ? 
 {{<collapsibleBlock groupId="technische_fragen">}}
 La livraison séparée de différents types d'éléments XML est possible. C'est-à-dire que les unités finales d’imputation non reliées à un cas peuvent en principe être livrées dans un autre fichier que les unités finales d’imputation reliées à un cas. Nous devons encore déterminer si nous pouvons mettre à disposition un outil pour la transformation des données à partir d'un fichier Excel. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Le fichier d'exportation SpiGes a-t-il la même structure que le fichier que les hôpitaux importent dans SpiGes ?
+{{<listItem>}}
+Le fichier d'exportation SpiGes a-t-il la même structure que le fichier que les hôpitaux importent dans SpiGes ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Il y aura plusieurs fichiers d'exportation. D'une part, il sera possible d'exporter le fichier XML que les hôpitaux importent, et d'autre part, il sera possible d'exporter dans un format plat (plusieurs fichiers CSV).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Dans le format XML, l'ordre des variables au sein d'une ligne joue-t-il un rôle ?
+{{<listItem>}}
+Dans le format XML, l'ordre des variables au sein d'une ligne joue-t-il un rôle ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - L'ordre des éléments est prédéfini et ne peut pas être modifié. Les éléments peuvent tout au plus être omis. Ainsi, pour l'élément «cas», les sous-éléments doivent toujours être indiqués dans l'ordre suivant : «administratif», «nouveau-nés», «psychiatrie», «CUFI cas», «diagnostics», «traitements», «médicaments», «facture», «mouvement des patients» et «données cantonales».  
 - L'ordre des attributs peut en revanche être choisi librement. Ainsi, par exemple, dans l'élément «administratif», il est possible d'indiquer aussi bien «...sexe="2" âge="37"...» que «...âge="37" sexe="2"...». 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. Des variables peuvent-elles également manquer sur une ligne si la clinique n'a rien à remplir sur cette ligne pour la variable correspondante ? Ou toutes les variables de l'interface doivent-elles toujours figurer sur chaque ligne ?
+{{<listItem>}}
+Des variables peuvent-elles également manquer sur une ligne si la clinique n'a rien à remplir sur cette ligne pour la variable correspondante ? Ou toutes les variables de l'interface doivent-elles toujours figurer sur chaque ligne ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Oui, les variables peuvent être manquantes. Certaines variables doivent cependant être obligatoirement indiquées. Elles sont marquées comme «required» dans le fichier de définition XSD («xs:attribute name="fall_id" use="required"»). Nous ajouterons également cette information dans la liste des variables.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-9. Les variables qui n'ont pas de contenu peuvent-elles être fournies avec une valeur NULL (p. ex. des lignes KTR complètes avec des NULL dans les variables où il n'y a rien) ?
+{{<listItem>}}
+Les variables qui n'ont pas de contenu peuvent-elles être fournies avec une valeur NULL (p. ex. des lignes KTR complètes avec des NULL dans les variables où il n'y a rien) ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Cela dépend des variables. Pour les variables KTR, il est possible de saisir toutes les variables avec la valeur "0". Les variables vides ("") ou les valeurs nulles ("NULL") ne sont toutefois pas autorisées. Si vous souhaitez le vérifier concrètement, vous pouvez valider votre fichier XML par rapport à la définition XSD. Il existe pour cela des outils gratuits en ligne. Veuillez noter qu'aucune donnée réelle ne peut être téléchargée sur de telles plateformes. Vous pouvez toutefois vérifier des exemples de fichiers fictifs. La plateforme SpiGes proposera également une telle validation. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10. Un logiciel de plausibilité analogue à Medplaus sera-t-il disponible, qui pourra être utilisé localement au sein des hôpitaux avant le téléchargement ?
+{{<listItem>}}
+Un logiciel de plausibilité analogue à Medplaus sera-t-il disponible, qui pourra être utilisé localement au sein des hôpitaux avant le téléchargement ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Un outil de contrôle sera mis à disposition via API (Application Programming Interfaces). Il ne sera toutefois disponible que dans le courant de l'année prochaine. D'ici là, nous recommandons de continuer à utiliser MedPlaus. Il y aura également une version pour l'année 2024.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-11. Sait-on déjà quelle sera la procédure concernant les données supplémentaires cantonales ? Plusieurs cantons (par ex. LU, GR, VS et VD) disposent déjà d'une ligne MK. En outre, les cantons de ZH et BE collectent également des données supplémentaires dans le cadre du SDEP. Savez-vous déjà si ces données seront intégrées dans l'exportation SpiGes ou si elles devront être exportées séparément ?
+{{<listItem>}}
+Sait-on déjà quelle sera la procédure concernant les données supplémentaires cantonales ? Plusieurs cantons (par ex. LU, GR, VS et VD) disposent déjà d'une ligne MK. En outre, les cantons de ZH et BE collectent également des données supplémentaires dans le cadre du SDEP. Savez-vous déjà si ces données seront intégrées dans l'exportation SpiGes ou si elles devront être exportées séparément ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Les données supplémentaires cantonales ont été prises en compte dans l'interface ; voir la description du fichier XML pour l'importation des données dans la plateforme SpiGes 1.3: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html) 
@@ -125,18 +147,24 @@ Un outil de contrôle sera mis à disposition via API (Application Programming I
 - Les données cantonales ne peuvent être exportées que par l'hôpital lui-même et par le canton. Il est probable que les données cantonales pour ces utilisateurs soient contenues dans le même fichier XML que les autres données.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-12. Est-ce qu’il sera possible d’effectuer des corrections directement sur la plateforme ?
+{{<listItem>}}
+Est-ce qu’il sera possible d’effectuer des corrections directement sur la plateforme ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Non, la plateforme n'offre pas la possibilité de saisir ou de corriger des données. L'objectif est de corriger les erreurs à la source, c'est-à-dire dans les systèmes des hôpitaux, afin que les exportations ultérieures soient cohérentes et que les erreurs n'apparaissent plus dans les prochains relevés.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-13. De nouveaux formats sont disponibles : Il existe de nouveaux formats. Par exemple, pour rech_betrag. Le format est N10.2 Nous supposons qu'il s'agit de l'indication des décimales. Dans ce cas, 2 décimales et une longueur totale de 12. Est-ce correct ?
+{{<listItem>}}
+De nouveaux formats sont disponibles : Il existe de nouveaux formats. Par exemple, pour rech_betrag. Le format est N10.2 Nous supposons qu'il s'agit de l'indication des décimales. Dans ce cas, 2 décimales et une longueur totale de 12. Est-ce correct ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virgule (et donc 8 chiffres avant la virgule au maximum).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-14. Nouvelles variables medi_id et rech_id : d'après la description, nous ne savons pas s'il s'agit de numéros d'ordre ou d'ID réels du système. Si oui, lesquelles ? En ce qui concerne medi_id, nous avons tout de suite pensé au code ATC_, mais il existe une variable supplémentaire pour cela. 
+{{<listItem>}}
+Nouvelles variables medi_id et rech_id : d'après la description, nous ne savons pas s'il s'agit de numéros d'ordre ou d'ID réels du système. Si oui, lesquelles ? En ce qui concerne medi_id, nous avons tout de suite pensé au code ATC_, mais il existe une variable supplémentaire pour cela. 
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Il s'agit, pour les deux nouvelles variables "medi_id" et "rech_id", d'identifiants qui sont nécessaires pour des raisons techniques afin d'assurer une attribution claire. Ceux-ci ne doivent pas obligatoirement commencer par 1, mais ils doivent être uniques pour chaque cas. 
@@ -144,11 +172,15 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 {{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-15.	Dans les fichiers d'exemple pour le fichier des identificateurs et le fichier des données, il y a deux champs pour la version. Or, ces versions ne correspondent pas. Ainsi, la version 1.0 est indiquée dans l'en-tête et la version 1.3 dans le tag Entreprise. Pourquoi les numéros de version sont-ils différents ? Comment savoir quand indiquer quel numéro de version ?
+{{<listItem>}}
+Dans les fichiers d'exemple pour le fichier des identificateurs et le fichier des données, il y a deux champs pour la version. Or, ces versions ne correspondent pas. Ainsi, la version 1.0 est indiquée dans l'en-tête et la version 1.3 dans le tag Entreprise. Pourquoi les numéros de version sont-ils différents ? Comment savoir quand indiquer quel numéro de version ?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" se trouve toujours ainsi . La version supérieure se réfère donc au "XML" lui-même, et la version inférieure au XML SpiGes spécifique.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/6_technische_fragen.md
+++ b/content/fr/FAQ/6_technische_fragen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 1. Existe-t-il un modèle de format pour l'importation de données dans l'application SpiGes ?
@@ -141,3 +142,5 @@ N10.2 désigne un nombre de 10 chiffres au total, dont 2 chiffres après la virg
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" se trouve toujours ainsi . La version supérieure se réfère donc au "XML" lui-même, et la version inférieure au XML SpiGes spécifique.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -17,8 +17,10 @@ Le regroupement des cas est géré à SpiGes conformément aux directives de Swi
 
 2. fall_id_ch : Qui génère ce numéro de cas et celui-ci est-il automatiquement déposé dans Opale (système IRP) ? Jusqu'à présent, nous pouvions générer automatiquement l'identifiant de cas dans les deux fichiers (données OFS et fichier des coûts par cas) dans Opale.
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - Le numéro de cas clair pour toute la Suisse est généré par la plateforme SpiGes. Lors d'une exportation de données à partir de la plateforme, ce fall_id_ch est à la disposition des utilisateurs de données. 
 - L'identifiant du cas, la variable fall_id, est généré par les hôpitaux. Les logiciels hospitaliers (comme Opale par exemple) devraient continuer à disposer de cette fonction. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Il existe des variables (p. ex. beatmung) pour lesquelles la référence temporelle est "cas complet" ou "année de relevé". Dans la plupart des hôpitaux, cette position n'est toutefois pas gérée sur l'axe temporel, mais une seule fois sur le cas. De même, dans l'ancien jeu de données MS, de telles positions n'étaient toujours livrées que pour les cas A. Comment envisagez-vous une livraison des cas B/C pour ces variables ?
@@ -28,8 +30,10 @@ Jusqu'à présent, il n'a pas été défini si ces variables doivent être fourn
 
 4. Comment est définie le «Transfert interne» ?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - Le transfert interne d’un domaine de prestations (soins aigus, psychiatrie, réadaptation) vers un autre domaine de prestations au sein du même hôpital (ree_gesv) 
 - ou pour les cas considérés comme étant en attente de placement. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5.	Est-il possible d’avoir une définition pour la valeur « 7 = rapatriement » ?
@@ -39,23 +43,29 @@ Rapatriement d'un patient ou d'une patiente avec une résidence principale suiss
 
 6. Comment est défini un « transfert » ? (p. ex. les codes «5 = transfert dans les 24 heures» et «6 = retransfert» de la variable type d'admission).
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - La variable Type d'admission existe déjà dans la MS et n'a pas non plus changé avec SpiGes. Un transfert se distingue d'un transfert interne par le fait qu'il n'a pas lieu dans le même hôpital (REEGESV), mais dans un autre hôpital (deux REEGESV différents). La définition se base sur les principes de SwissDRG SA, que vous trouverez ici:  <a href="https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions"> https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions </a> 
 -	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 7. Comment coder les cas qui passent de la réadaptation (tarif ST-REHA) aux soins de longue durée (tarif "taxe de soins") du même établissement ? Les variables 1.2.V02 et 1.5.V03 ne nous permettent pas d'indiquer "soins de longue durée, même établissement".
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 C'était déjà le cas pour la MS ; le cas change de réadaptation à SOMED (même établissement) ; pour le code 2, les deux possibilités sont simplement incluses (même établissement ou autre établissement). Le cas doit être codé comme suit :           
 sortie_séjour : 2 = établ. de santé non hospit. médicalisé             
 entrée_séjour : 84 = division/clinique de réadaptation, même établissement  
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ### Variable "(Pays de résidence)"
 
 8. La description de la variable mentionne une répartition séparée des pays extra-européens en régions. Cette liste existe-t-elle déjà ou sera-t-elle publiée ?
 {{<collapsibleBlock groupId="admninistratives">}}
-- La procédure et la liste sont restées les mêmes que pour la MS. Ci-joint le lien vers la liste :  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a> 
+{{<markdown>}}
+- La procédure et la liste sont restées les mêmes que pour la MS. Ci-joint le lien vers la liste : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html) 
 - Pour les pays extra-européens, il est possible de saisir des régions, mais aussi d'indiquer les codes des pays. Ceci est déjà le cas dans la MS et n'a pas changé. Le format est alphanumérique et peut donc contenir aussi bien des chiffres que des lettres. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ###	Variable "Classe d'assurance" 
@@ -67,8 +77,10 @@ La formulation peut en effet porter à confusion. Pour qu'il n'y ait pas de miss
 
 10.	Variable "Classe d'assurance" : selon notre administration des patients, il est difficile d'obtenir l'information pour les cas avec une "assurance Flex" et de la consigner avec "8 = autre".  Y a-t-il un problème lors des analyses ultérieures ou quelles sont les conséquences sur les statistiques si nous n'indiquons pas (ou ne pouvons pas indiquer) "8=autres" ?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - Les cas Flex et tous les autres modèles d'assurance qui deviennent de plus en plus populaires ne sont pas faciles à représenter. Malgré ces difficultés, d’un point de vue statistique, cela n’est pas dramatique pour la variable Classe d'assurance si l’information n’est pas sure. En cas de doute, ces cas devraient être représentés en tant que semi-privés.
-- La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.  
+- La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.
+{{</markdown>}}  
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
+{{<numberedList>}}
 1. Le jeu de données SpiGes attend-il les cas de parenthèses de cas (= cas regroupés) ? Dans le domaine de la psychiatrie, l'ANQ attend un jeu de données avec les cas individuels, donc des cas non regroupés. Existe-t-il déjà un échange entre vous et l'ANQ concernant l'utilisation du jeu de données SpiGes ?
 {{<collapsibleBlock groupId="admninistratives">}}
 Le regroupement des cas est géré à SpiGes conformément aux directives de SwissDRG SA. Nous sommes en discussion avec l'ANQ concernant la gestion des cas non regroupés.
@@ -82,5 +83,5 @@ La formulation peut en effet porter à confusion. Pour qu'il n'y ait pas de miss
 - La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.
 {{</markdown>}}  
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -11,46 +11,59 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
 {{<numberedList>}}
-1. Le jeu de données SpiGes attend-il les cas de parenthèses de cas (= cas regroupés) ? Dans le domaine de la psychiatrie, l'ANQ attend un jeu de données avec les cas individuels, donc des cas non regroupés. Existe-t-il déjà un échange entre vous et l'ANQ concernant l'utilisation du jeu de données SpiGes ?
+{{<listItem>}}
+Le jeu de données SpiGes attend-il les cas de parenthèses de cas (= cas regroupés) ? Dans le domaine de la psychiatrie, l'ANQ attend un jeu de données avec les cas individuels, donc des cas non regroupés. Existe-t-il déjà un échange entre vous et l'ANQ concernant l'utilisation du jeu de données SpiGes ?
 {{<collapsibleBlock groupId="admninistratives">}}
 Le regroupement des cas est géré à SpiGes conformément aux directives de SwissDRG SA. Nous sommes en discussion avec l'ANQ concernant la gestion des cas non regroupés.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. fall_id_ch : Qui génère ce numéro de cas et celui-ci est-il automatiquement déposé dans Opale (système IRP) ? Jusqu'à présent, nous pouvions générer automatiquement l'identifiant de cas dans les deux fichiers (données OFS et fichier des coûts par cas) dans Opale.
+{{<listItem>}}
+fall_id_ch : Qui génère ce numéro de cas et celui-ci est-il automatiquement déposé dans Opale (système IRP) ? Jusqu'à présent, nous pouvions générer automatiquement l'identifiant de cas dans les deux fichiers (données OFS et fichier des coûts par cas) dans Opale.
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Le numéro de cas clair pour toute la Suisse est généré par la plateforme SpiGes. Lors d'une exportation de données à partir de la plateforme, ce fall_id_ch est à la disposition des utilisateurs de données. 
 - L'identifiant du cas, la variable fall_id, est généré par les hôpitaux. Les logiciels hospitaliers (comme Opale par exemple) devraient continuer à disposer de cette fonction. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Il existe des variables (p. ex. beatmung) pour lesquelles la référence temporelle est "cas complet" ou "année de relevé". Dans la plupart des hôpitaux, cette position n'est toutefois pas gérée sur l'axe temporel, mais une seule fois sur le cas. De même, dans l'ancien jeu de données MS, de telles positions n'étaient toujours livrées que pour les cas A. Comment envisagez-vous une livraison des cas B/C pour ces variables ?
+{{<listItem>}}
+Il existe des variables (p. ex. beatmung) pour lesquelles la référence temporelle est "cas complet" ou "année de relevé". Dans la plupart des hôpitaux, cette position n'est toutefois pas gérée sur l'axe temporel, mais une seule fois sur le cas. De même, dans l'ancien jeu de données MS, de telles positions n'étaient toujours livrées que pour les cas A. Comment envisagez-vous une livraison des cas B/C pour ces variables ?
 {{<collapsibleBlock groupId="admninistratives">}}
 Jusqu'à présent, il n'a pas été défini si ces variables doivent être fournies pour les cas B et C. En principe, il devrait être possible de fournir ces informations, c'est la seule façon de calculer les taux d'occupation à partir des données. Toutefois, il est probable que de nombreux hôpitaux soient comme vous et ne disposent pas des données pour les cas B et C. Dans ce cas, les variables pour les cas B et C peuvent être laissées vides.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Comment est définie le «Transfert interne» ?
+{{<listItem>}}
+Comment est définie le «Transfert interne» ?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Le transfert interne d’un domaine de prestations (soins aigus, psychiatrie, réadaptation) vers un autre domaine de prestations au sein du même hôpital (ree_gesv) 
 - ou pour les cas considérés comme étant en attente de placement. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5.	Est-il possible d’avoir une définition pour la valeur « 7 = rapatriement » ?
+{{<listItem>}}
+Est-il possible d’avoir une définition pour la valeur « 7 = rapatriement » ?
 {{<collapsibleBlock groupId="admninistratives">}}
 Rapatriement d'un patient ou d'une patiente avec une résidence principale suisse de l'étranger vers la Suisse, sans exigences particulières quant au moyen de transport ou à l'accompagnement.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Comment est défini un « transfert » ? (p. ex. les codes «5 = transfert dans les 24 heures» et «6 = retransfert» de la variable type d'admission).
+{{<listItem>}}
+Comment est défini un « transfert » ? (p. ex. les codes «5 = transfert dans les 24 heures» et «6 = retransfert» de la variable type d'admission).
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - La variable Type d'admission existe déjà dans la MS et n'a pas non plus changé avec SpiGes. Un transfert se distingue d'un transfert interne par le fait qu'il n'a pas lieu dans le même hôpital (REEGESV), mais dans un autre hôpital (deux REEGESV différents). La définition se base sur les principes de SwissDRG SA, que vous trouverez ici:  <a href="https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions"> https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions </a> 
 -	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Comment coder les cas qui passent de la réadaptation (tarif ST-REHA) aux soins de longue durée (tarif "taxe de soins") du même établissement ? Les variables 1.2.V02 et 1.5.V03 ne nous permettent pas d'indiquer "soins de longue durée, même établissement".
+{{<listItem>}}
+Comment coder les cas qui passent de la réadaptation (tarif ST-REHA) aux soins de longue durée (tarif "taxe de soins") du même établissement ? Les variables 1.2.V02 et 1.5.V03 ne nous permettent pas d'indiquer "soins de longue durée, même établissement".
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 C'était déjà le cas pour la MS ; le cas change de réadaptation à SOMED (même établissement) ; pour le code 2, les deux possibilités sont simplement incluses (même établissement ou autre établissement). Le cas doit être codé comme suit :           
@@ -58,30 +71,38 @@ sortie_séjour : 2 = établ. de santé non hospit. médicalisé
 entrée_séjour : 84 = division/clinique de réadaptation, même établissement  
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ### Variable "(Pays de résidence)"
 
-8. La description de la variable mentionne une répartition séparée des pays extra-européens en régions. Cette liste existe-t-elle déjà ou sera-t-elle publiée ?
+{{<listItem>}}
+La description de la variable mentionne une répartition séparée des pays extra-européens en régions. Cette liste existe-t-elle déjà ou sera-t-elle publiée ?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - La procédure et la liste sont restées les mêmes que pour la MS. Ci-joint le lien vers la liste : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html) 
 - Pour les pays extra-européens, il est possible de saisir des régions, mais aussi d'indiquer les codes des pays. Ceci est déjà le cas dans la MS et n'a pas changé. Le format est alphanumérique et peut donc contenir aussi bien des chiffres que des lettres. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ###	Variable "Classe d'assurance" 
 
-9. Dans la description de la variable, il est indiqué qu'il faut l'indiquer pour tous, sauf pour les personnes payant elles-mêmes. Mais dans le xsd, le champ est "required". Que faut-il alors fournir pour les personnes payant elles-mêmes ?
+{{<listItem>}}
+Dans la description de la variable, il est indiqué qu'il faut l'indiquer pour tous, sauf pour les personnes payant elles-mêmes. Mais dans le xsd, le champ est "required". Que faut-il alors fournir pour les personnes payant elles-mêmes ?
 {{<collapsibleBlock groupId="admninistratives">}}
 La formulation peut en effet porter à confusion. Pour qu'il n'y ait pas de missings ici, required a été présupposé. Cela concerne aussi les self-payeurs, qui sont codés avec 9=inconnu.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10.	Variable "Classe d'assurance" : selon notre administration des patients, il est difficile d'obtenir l'information pour les cas avec une "assurance Flex" et de la consigner avec "8 = autre".  Y a-t-il un problème lors des analyses ultérieures ou quelles sont les conséquences sur les statistiques si nous n'indiquons pas (ou ne pouvons pas indiquer) "8=autres" ?
+{{<listItem>}}
+Variable "Classe d'assurance" : selon notre administration des patients, il est difficile d'obtenir l'information pour les cas avec une "assurance Flex" et de la consigner avec "8 = autre".  Y a-t-il un problème lors des analyses ultérieures ou quelles sont les conséquences sur les statistiques si nous n'indiquons pas (ou ne pouvons pas indiquer) "8=autres" ?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Les cas Flex et tous les autres modèles d'assurance qui deviennent de plus en plus populaires ne sont pas faciles à représenter. Malgré ces difficultés, d’un point de vue statistique, cela n’est pas dramatique pour la variable Classe d'assurance si l’information n’est pas sure. En cas de doute, ces cas devraient être représentés en tant que semi-privés.
 - La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.
 {{</markdown>}}  
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
 1. Le jeu de données SpiGes attend-il les cas de parenthèses de cas (= cas regroupés) ? Dans le domaine de la psychiatrie, l'ANQ attend un jeu de données avec les cas individuels, donc des cas non regroupés. Existe-t-il déjà un échange entre vous et l'ANQ concernant l'utilisation du jeu de données SpiGes ?
@@ -69,3 +70,5 @@ La formulation peut en effet porter à confusion. Pour qu'il n'y ait pas de miss
 - Les cas Flex et tous les autres modèles d'assurance qui deviennent de plus en plus populaires ne sont pas faciles à représenter. Malgré ces difficultés, d’un point de vue statistique, cela n’est pas dramatique pour la variable Classe d'assurance si l’information n’est pas sure. En cas de doute, ces cas devraient être représentés en tant que semi-privés.
 - La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.  
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -16,10 +16,8 @@ Le regroupement des cas est géré à SpiGes conformément aux directives de Swi
 
 2. fall_id_ch : Qui génère ce numéro de cas et celui-ci est-il automatiquement déposé dans Opale (système IRP) ? Jusqu'à présent, nous pouvions générer automatiquement l'identifiant de cas dans les deux fichiers (données OFS et fichier des coûts par cas) dans Opale.
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Le numéro de cas clair pour toute la Suisse est généré par la plateforme SpiGes. Lors d'une exportation de données à partir de la plateforme, ce fall_id_ch est à la disposition des utilisateurs de données. </li>
-<li> L'identifiant du cas, la variable fall_id, est généré par les hôpitaux. Les logiciels hospitaliers (comme Opale par exemple) devraient continuer à disposer de cette fonction. </li>
-</ul>
+- Le numéro de cas clair pour toute la Suisse est généré par la plateforme SpiGes. Lors d'une exportation de données à partir de la plateforme, ce fall_id_ch est à la disposition des utilisateurs de données. 
+- L'identifiant du cas, la variable fall_id, est généré par les hôpitaux. Les logiciels hospitaliers (comme Opale par exemple) devraient continuer à disposer de cette fonction. 
 {{</collapsibleBlock>}}
 
 3. Il existe des variables (p. ex. beatmung) pour lesquelles la référence temporelle est "cas complet" ou "année de relevé". Dans la plupart des hôpitaux, cette position n'est toutefois pas gérée sur l'axe temporel, mais une seule fois sur le cas. De même, dans l'ancien jeu de données MS, de telles positions n'étaient toujours livrées que pour les cas A. Comment envisagez-vous une livraison des cas B/C pour ces variables ?
@@ -29,10 +27,8 @@ Jusqu'à présent, il n'a pas été défini si ces variables doivent être fourn
 
 4. Comment est définie le «Transfert interne» ?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Le transfert interne d’un domaine de prestations (soins aigus, psychiatrie, réadaptation) vers un autre domaine de prestations au sein du même hôpital (ree_gesv) </li>
-<li> ou pour les cas considérés comme étant en attente de placement. </li>
-</ul>
+- Le transfert interne d’un domaine de prestations (soins aigus, psychiatrie, réadaptation) vers un autre domaine de prestations au sein du même hôpital (ree_gesv) 
+- ou pour les cas considérés comme étant en attente de placement. 
 {{</collapsibleBlock>}}
 
 5.	Est-il possible d’avoir une définition pour la valeur « 7 = rapatriement » ?
@@ -42,10 +38,8 @@ Rapatriement d'un patient ou d'une patiente avec une résidence principale suiss
 
 6. Comment est défini un « transfert » ? (p. ex. les codes «5 = transfert dans les 24 heures» et «6 = retransfert» de la variable type d'admission).
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> La variable Type d'admission existe déjà dans la MS et n'a pas non plus changé avec SpiGes. Un transfert se distingue d'un transfert interne par le fait qu'il n'a pas lieu dans le même hôpital (REEGESV), mais dans un autre hôpital (deux REEGESV différents). La définition se base sur les principes de SwissDRG SA, que vous trouverez ici:  <a href="https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions"> https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions </a> </li>
-<li>	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital </li>
-</ul>
+- La variable Type d'admission existe déjà dans la MS et n'a pas non plus changé avec SpiGes. Un transfert se distingue d'un transfert interne par le fait qu'il n'a pas lieu dans le même hôpital (REEGESV), mais dans un autre hôpital (deux REEGESV différents). La définition se base sur les principes de SwissDRG SA, que vous trouverez ici:  <a href="https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions"> https://www.swissdrg.org/fr/somatique-aigue/systeme-swissdrg-1302024/regles-et-definitions </a> 
+-	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital 
 {{</collapsibleBlock>}}
 
 7. Comment coder les cas qui passent de la réadaptation (tarif ST-REHA) aux soins de longue durée (tarif "taxe de soins") du même établissement ? Les variables 1.2.V02 et 1.5.V03 ne nous permettent pas d'indiquer "soins de longue durée, même établissement".
@@ -59,10 +53,8 @@ entrée_séjour : 84 = division/clinique de réadaptation, même établissement
 
 8. La description de la variable mentionne une répartition séparée des pays extra-européens en régions. Cette liste existe-t-elle déjà ou sera-t-elle publiée ?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> La procédure et la liste sont restées les mêmes que pour la MS. Ci-joint le lien vers la liste :  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a> </li>
-<li> Pour les pays extra-européens, il est possible de saisir des régions, mais aussi d'indiquer les codes des pays. Ceci est déjà le cas dans la MS et n'a pas changé. Le format est alphanumérique et peut donc contenir aussi bien des chiffres que des lettres. </li>
-</ul>
+- La procédure et la liste sont restées les mêmes que pour la MS. Ci-joint le lien vers la liste :  <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html </a> 
+- Pour les pays extra-européens, il est possible de saisir des régions, mais aussi d'indiquer les codes des pays. Ceci est déjà le cas dans la MS et n'a pas changé. Le format est alphanumérique et peut donc contenir aussi bien des chiffres que des lettres. 
 {{</collapsibleBlock>}}
 
 ###	Variable "Classe d'assurance" 
@@ -74,8 +66,6 @@ La formulation peut en effet porter à confusion. Pour qu'il n'y ait pas de miss
 
 10.	Variable "Classe d'assurance" : selon notre administration des patients, il est difficile d'obtenir l'information pour les cas avec une "assurance Flex" et de la consigner avec "8 = autre".  Y a-t-il un problème lors des analyses ultérieures ou quelles sont les conséquences sur les statistiques si nous n'indiquons pas (ou ne pouvons pas indiquer) "8=autres" ?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Les cas Flex et tous les autres modèles d'assurance qui deviennent de plus en plus populaires ne sont pas faciles à représenter. Malgré ces difficultés, d’un point de vue statistique, cela n’est pas dramatique pour la variable Classe d'assurance si l’information n’est pas sure. En cas de doute, ces cas devraient être représentés en tant que semi-privés.</li>
-<li> La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.  </li>
-</ul>
+- Les cas Flex et tous les autres modèles d'assurance qui deviennent de plus en plus populaires ne sont pas faciles à représenter. Malgré ces difficultés, d’un point de vue statistique, cela n’est pas dramatique pour la variable Classe d'assurance si l’information n’est pas sure. En cas de doute, ces cas devraient être représentés en tant que semi-privés.
+- La variable "liegeklasse" est en revanche centrale pour la représentation de l'ITAR_K. Il n'y a pas non plus de catégorie "autre" et les cas avec "inconnu" seront examinés de près. En fonction de la valeur de cette variable, les cas sont attribués dans des colonnes différentes dans l’ITAR_K®.  
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Falldaten/1_administratives.md
+++ b/content/fr/FAQ/Falldaten/1_administratives.md
@@ -44,8 +44,8 @@ Rapatriement d'un patient ou d'une patiente avec une résidence principale suiss
 
 7. Comment coder les cas qui passent de la réadaptation (tarif ST-REHA) aux soins de longue durée (tarif "taxe de soins") du même établissement ? Les variables 1.2.V02 et 1.5.V03 ne nous permettent pas d'indiquer "soins de longue durée, même établissement".
 {{<collapsibleBlock groupId="admninistratives">}}
-C'était déjà le cas pour la MS ; le cas change de réadaptation à SOMED (même établissement) ; pour le code 2, les deux possibilités sont simplement incluses (même établissement ou autre établissement). Le cas doit être codé comme suit : <br />
-sortie_séjour : 2 = établ. de santé non hospit. médicalisé  <br />
+C'était déjà le cas pour la MS ; le cas change de réadaptation à SOMED (même établissement) ; pour le code 2, les deux possibilités sont simplement incluses (même établissement ou autre établissement). Le cas doit être codé comme suit :           
+sortie_séjour : 2 = établ. de santé non hospit. médicalisé             
 entrée_séjour : 84 = division/clinique de réadaptation, même établissement  
 {{</collapsibleBlock>}}
 

--- a/content/fr/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/fr/FAQ/Falldaten/3_psychiatrie.md
@@ -12,7 +12,9 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable «psy_zivilstand»: que signifie le code «5 = non marié» ou comment se distingue-t-il de «célibataire» ?
 {{<collapsibleBlock groupId="psychiatrie">}}
-La liste des codes de la variable «état civil» est utilisée de manière uniforme par l'OFS. L'état civil «non marié» peut résulter d’une déclaration d’invalidité d’une union antérieure ou d’une déclaration de disparition de l’ancien conjoint. Voir le lien : : <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html </a> 
+{{<markdown>}}
+La liste des codes de la variable «état civil» est utilisée de manière uniforme par l'OFS. L'état civil «non marié» peut résulter d’une déclaration d’invalidité d’une union antérieure ou d’une déclaration de disparition de l’ancien conjoint. Voir le lien : : [https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html) 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/fr/FAQ/Falldaten/3_psychiatrie.md
@@ -10,11 +10,12 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
+{{<numberedList>}}
 1. Variable «psy_zivilstand»: que signifie le code «5 = non marié» ou comment se distingue-t-il de «célibataire» ?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
 La liste des codes de la variable «état civil» est utilisée de manière uniforme par l'OFS. L'état civil «non marié» peut résulter d’une déclaration d’invalidité d’une union antérieure ou d’une déclaration de disparition de l’ancien conjoint. Voir le lien : : [https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html) 
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/fr/FAQ/Falldaten/3_psychiatrie.md
@@ -7,9 +7,12 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variable «psy_zivilstand»: que signifie le code «5 = non marié» ou comment se distingue-t-il de «célibataire» ?
 {{<collapsibleBlock groupId="psychiatrie">}}
 La liste des codes de la variable «état civil» est utilisée de manière uniforme par l'OFS. L'état civil «non marié» peut résulter d’une déclaration d’invalidité d’une union antérieure ou d’une déclaration de disparition de l’ancien conjoint. Voir le lien : : <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html </a> 
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/fr/FAQ/Falldaten/3_psychiatrie.md
@@ -11,11 +11,14 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 {{<numberedList>}}
-1. Variable «psy_zivilstand»: que signifie le code «5 = non marié» ou comment se distingue-t-il de «célibataire» ?
+{{<listItem>}}
+Variable «psy_zivilstand»: que signifie le code «5 = non marié» ou comment se distingue-t-il de «célibataire» ?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
 La liste des codes de la variable «état civil» est utilisée de manière uniforme par l'OFS. L'état civil «non marié» peut résulter d’une déclaration d’invalidité d’une union antérieure ou d’une déclaration de disparition de l’ancien conjoint. Voir le lien : : [https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/population/effectif-evolution/etat-civil.html) 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="diagnose">}}
 
+{{<numberedList>}}
 1.	Variable POA : Pourriez-vous nous indiquer à quelle fin est utilisée la variable «diagnose_poa» ?  
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
@@ -110,5 +111,5 @@ DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacré
   </tr>
 </table>
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -11,14 +11,17 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 {{<numberedList>}}
-1.	Variable POA : Pourriez-vous nous indiquer à quelle fin est utilisée la variable «diagnose_poa» ?  
+{{<listItem>}}
+Variable POA : Pourriez-vous nous indiquer à quelle fin est utilisée la variable «diagnose_poa» ?  
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 L'indication «POA» peut être utilisée, entre autres, pour améliorer la qualité et la sécurité des patients. Voir par exemple la communication du canton de Zurich à ce sujet. [Present on admission - Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Variable «diagnose_zusatz» : quelles indications doivent être données ici pour les codes avec étoile et les codes avec point d'exclamation ?
+{{<listItem>}}
+Variable «diagnose_zusatz» : quelles indications doivent être données ici pour les codes avec étoile et les codes avec point d'exclamation ?
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 -	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. 
@@ -111,5 +114,7 @@ DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacré
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -20,13 +20,12 @@ L'indication «POA» peut être utilisée, entre autres, pour améliorer la qual
 -	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. 
 -	Les codes étoile ne sont pas marqués comme tels, l’association se fait suivant CIM-10-GM. 
 
-<p>
-<b>Exemple 4</b> dans le manuel du codage (page 38) : <br />
-DP E10.73† Diabète sucré, type 1, avec complications multiples, désigné comme décompensé <br />
-DS I79.2* Angiopathie périphérique au cours de maladies classées ailleurs <br />
-DS H36.0* Rétinopathie diabétique <br />
-DS N08.3* Glomérulopathie au cours du diabète sucré  <br />
-…est saisi dans <b>SpiGes</b> comme suit : <br />
+**Exemple 4** dans le manuel du codage (page 38) :       
+DP E10.73† Diabète sucré, type 1, avec complications multiples, désigné comme décompensé      
+DS I79.2* Angiopathie périphérique au cours de maladies classées ailleurs       
+DS H36.0* Rétinopathie diabétique       
+DS N08.3* Glomérulopathie au cours du diabète sucré       
+…est saisi dans <b>SpiGes</b> comme suit :      
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -54,17 +53,15 @@ DS N08.3* Glomérulopathie au cours du diabète sucré  <br />
     <td> E10.73 </td>
   </tr>
 </table>
-</p>
 
-<p>
-<b>Exemple 4</b> dans le manuel du codage (page 40) :  <br />
-DP S37.03 Rupture totale du parenchyme rénal <br />
-L 2  <br />
-DS V99! Accident de transport <br />
-DS S36.03 Déchirure de la rate, avec atteinte du parenchyme <br />
-DS S36.49 Autres parties et parties multiples de l’intestin grêle <br />
-DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacrée et du bassin) associée à une lésion intraabdominale <br />
-…est saisi dans SpiGes comme suit : <br />
+**Exemple 4** dans le manuel du codage (page 40) :       
+DP S37.03 Rupture totale du parenchyme rénal      
+L 2       
+DS V99! Accident de transport       
+DS S36.03 Déchirure de la rate, avec atteinte du parenchyme       
+DS S36.49 Autres parties et parties multiples de l’intestin grêle       
+DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacrée et du bassin) associée à une lésion intraabdominale       
+…est saisi dans SpiGes comme suit :       
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -107,5 +104,4 @@ DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacré
     <td> S37.03 </td>
   </tr>
 </table>
-</p>
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1.	Variable POA : Pourriez-vous nous indiquer à quelle fin est utilisée la variable «diagnose_poa» ?  
@@ -104,3 +105,5 @@ DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacré
   </tr>
 </table>
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -16,10 +16,10 @@ L'indication «POA» peut être utilisée, entre autres, pour améliorer la qual
 
 2. Variable «diagnose_zusatz» : quelles indications doivent être données ici pour les codes avec étoile et les codes avec point d'exclamation ?
 {{<collapsibleBlock groupId="diagnose">}}
-<ul>
-<li>	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. </li>
-<li>		Les codes étoile ne sont pas marqués comme tels, l’association se fait suivant CIM-10-GM. </li>
-</ul>
+
+-	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. 
+-	Les codes étoile ne sont pas marqués comme tels, l’association se fait suivant CIM-10-GM. 
+
 <p>
 <b>Exemple 4</b> dans le manuel du codage (page 38) : <br />
 DP E10.73† Diabète sucré, type 1, avec complications multiples, désigné comme décompensé <br />

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -12,11 +12,14 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1.	Variable POA : Pourriez-vous nous indiquer à quelle fin est utilisée la variable «diagnose_poa» ?  
 {{<collapsibleBlock groupId="diagnose">}}
-L'indication «POA» peut être utilisée, entre autres, pour améliorer la qualité et la sécurité des patients. Voir par exemple la communication du canton de Zurich à ce sujet. <a href="https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf"> Present on admission - Informationen zur Erfassung (zh.ch)</a>
+{{<markdown>}}
+L'indication «POA» peut être utilisée, entre autres, pour améliorer la qualité et la sécurité des patients. Voir par exemple la communication du canton de Zurich à ce sujet. [Present on admission - Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Variable «diagnose_zusatz» : quelles indications doivent être données ici pour les codes avec étoile et les codes avec point d'exclamation ?
 {{<collapsibleBlock groupId="diagnose">}}
+{{<markdown>}}
 -	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. 
 -	Les codes étoile ne sont pas marqués comme tels, l’association se fait suivant CIM-10-GM. 
 
@@ -25,7 +28,8 @@ DP E10.73† Diabète sucré, type 1, avec complications multiples, désigné co
 DS I79.2* Angiopathie périphérique au cours de maladies classées ailleurs       
 DS H36.0* Rétinopathie diabétique       
 DS N08.3* Glomérulopathie au cours du diabète sucré       
-…est saisi dans <b>SpiGes</b> comme suit :      
+…est saisi dans <b>SpiGes</b> comme suit : 
+{{</markdown>}}     
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -53,7 +57,7 @@ DS N08.3* Glomérulopathie au cours du diabète sucré
     <td> E10.73 </td>
   </tr>
 </table>
-
+{{<markdown>}}
 **Exemple 4** dans le manuel du codage (page 40) :       
 DP S37.03 Rupture totale du parenchyme rénal      
 L 2       
@@ -61,7 +65,8 @@ DS V99! Accident de transport
 DS S36.03 Déchirure de la rate, avec atteinte du parenchyme       
 DS S36.49 Autres parties et parties multiples de l’intestin grêle       
 DS S31.83! Plaie ouverte (toute partie de l’abdomen, de la région lombosacrée et du bassin) associée à une lésion intraabdominale       
-…est saisi dans SpiGes comme suit :       
+…est saisi dans SpiGes comme suit :    
+{{</markdown>}}   
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>

--- a/content/fr/FAQ/Falldaten/4_diagnose.md
+++ b/content/fr/FAQ/Falldaten/4_diagnose.md
@@ -16,7 +16,6 @@ L'indication «POA» peut être utilisée, entre autres, pour améliorer la qual
 
 2. Variable «diagnose_zusatz» : quelles indications doivent être données ici pour les codes avec étoile et les codes avec point d'exclamation ?
 {{<collapsibleBlock groupId="diagnose">}}
-
 -	Pour les codes étoile, le code dague associé est indiqué ici. Pour les codes avec points d’exclamation, le code est à préciser. 
 -	Les codes étoile ne sont pas marqués comme tels, l’association se fait suivant CIM-10-GM. 
 

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -12,6 +12,7 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}
 
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
+{{<markdown>}}
 - Selon la description de la variable           
 Numéro unique attribué au traitement, dans l'ordre.             
 1 = traitement 1            
@@ -23,9 +24,9 @@ Les critères suivants sont recommandés pour l'ordre des traitements :
 2. Procédures de traitement des diagnostics supplémentaires 
 3. Procédures de définition du diagnostic principal 
 4. Procédures de définition des diagnostics supplémentaires 
-5. Autres procédures 
-
+5. Autres procédures    
 - Pour les items HoNOS, nous recommandons une numérotation chronologique (mesures HoNOS antérieures = ID inférieures, mesures HoNOS ultérieures = ID supérieures).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Nous craignons un peu que, surtout dans les premiers temps, ces données ne soient pas entièrement saisies et qu'il y ait beaucoup de retouches. C'est pourquoi nous aimerions définir le champ comme obligatoire pour les codes CHOP concernés. Existe-t-il pour le catalogue CHOP une attribution des codes considérés comme opérationnels ou interventionnels ?

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
@@ -38,3 +39,5 @@ L'OFS est conscient que les données seront incomplètes lors de l'introduction 
 Le nombre d'opérateurs pouvant être comptabilisé pour une opération est une question conceptuelle et peut varier d'un canton à l'autre (en règle générale, 2 est une valeur indicative). Techniquement, il est possible de saisir plusieurs médecins pratiquant les opérations.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,6 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}
 
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
-
 - Selon la description de la variable           
 Numéro unique attribué au traitement, dans l'ordre.             
 1 = traitement 1            

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,8 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 {{<numberedList>}}
-1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
+{{<listItem>}}
+Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
 - Selon la description de la variable           
@@ -29,17 +30,23 @@ Les critères suivants sont recommandés pour l'ordre des traitements :
 - Pour les items HoNOS, nous recommandons une numérotation chronologique (mesures HoNOS antérieures = ID inférieures, mesures HoNOS ultérieures = ID supérieures).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Nous craignons un peu que, surtout dans les premiers temps, ces données ne soient pas entièrement saisies et qu'il y ait beaucoup de retouches. C'est pourquoi nous aimerions définir le champ comme obligatoire pour les codes CHOP concernés. Existe-t-il pour le catalogue CHOP une attribution des codes considérés comme opérationnels ou interventionnels ?
+{{<listItem>}}
+Nous craignons un peu que, surtout dans les premiers temps, ces données ne soient pas entièrement saisies et qu'il y ait beaucoup de retouches. C'est pourquoi nous aimerions définir le champ comme obligatoire pour les codes CHOP concernés. Existe-t-il pour le catalogue CHOP une attribution des codes considérés comme opérationnels ou interventionnels ?
 {{<collapsibleBlock groupId="behandlungen">}}
 L'OFS est conscient que les données seront incomplètes lors de l'introduction de cette nouvelle donnée. Après la phase de consolidation habituelle, on verra quelles précisions sont nécessaires. Il n'est pas du tout possible de déterminer clairement pour chaque code CHOP s'il nécessite ou non une indication de temps. Ce sont d'autres caractéristiques qui sont ici déterminantes : si le traitement est en rapport avec l'utilisation d'une salle d'opération ou d'un laboratoire de cathétérisme cardiaque
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Médecins pratiquant les opérations : Nous avons ici un problème de compréhension dans l'interprétation des données du fichier XML. La description de la variable indique que deux médecins pratiquant les opérations au maximum peuvent être comptabilisés par opération. Dans l'aperçu, l'attribut ne permet pas de savoir s'il peut être exporté plusieurs fois.
+{{<listItem>}}
+Médecins pratiquant les opérations : Nous avons ici un problème de compréhension dans l'interprétation des données du fichier XML. La description de la variable indique que deux médecins pratiquant les opérations au maximum peuvent être comptabilisés par opération. Dans l'aperçu, l'attribut ne permet pas de savoir s'il peut être exporté plusieurs fois.
 {{<insertImage image="Image1.jpg" class="edge max-w-90">}}
 {{<collapsibleBlock groupId="behandlungen">}}
 Le nombre d'opérateurs pouvant être comptabilisé pour une opération est une question conceptuelle et peut varier d'un canton à l'autre (en règle générale, 2 est une valeur indicative). Techniquement, il est possible de saisir plusieurs médecins pratiquant les opérations.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
+{{<numberedList>}}
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
@@ -40,5 +41,5 @@ L'OFS est conscient que les données seront incomplètes lors de l'introduction 
 Le nombre d'opérateurs pouvant être comptabilisé pour une opération est une question conceptuelle et peut varier d'un canton à l'autre (en règle générale, 2 est une valeur indicative). Techniquement, il est possible de saisir plusieurs médecins pratiquant les opérations.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -11,8 +11,8 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}
 
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
-<ul>
-<li> Selon la description de la variable <br />
+
+- Selon la description de la variable <br />
 Numéro unique attribué au traitement, dans l'ordre. <br />
 1 = traitement 1 <br />
 2 = traitement 2 <br />
@@ -20,17 +20,17 @@ Numéro unique attribué au traitement, dans l'ordre. <br />
 (…) etc. -> illimité <br />
 Les critères suivants sont recommandés pour l'ordre des traitements :
 <ol>
-<li> Procédures de traitement du diagnostic principal </li>
-<li> Procédures de traitement des diagnostics supplémentaires </li>
-<li> Procédures de définition du diagnostic principal </li>
-<li> Procédures de définition des diagnostics supplémentaires </li>
-<li> Autres procédures </li>
+- Procédures de traitement du diagnostic principal 
+- Procédures de traitement des diagnostics supplémentaires 
+- Procédures de définition du diagnostic principal 
+- Procédures de définition des diagnostics supplémentaires 
+- Autres procédures 
 </ol>
-</li>
-<li>
+
+-
 Pour les items HoNOS, nous recommandons une numérotation chronologique (mesures HoNOS antérieures = ID inférieures, mesures HoNOS ultérieures = ID supérieures).
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 2. Nous craignons un peu que, surtout dans les premiers temps, ces données ne soient pas entièrement saisies et qu'il y ait beaucoup de retouches. C'est pourquoi nous aimerions définir le champ comme obligatoire pour les codes CHOP concernés. Existe-t-il pour le catalogue CHOP une attribution des codes considérés comme opérationnels ou interventionnels ?

--- a/content/fr/FAQ/Falldaten/5_behandlungen.md
+++ b/content/fr/FAQ/Falldaten/5_behandlungen.md
@@ -12,25 +12,20 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="behandlungen">}
 1. Variable «behandlung_id» (traitement_id) : existe-t-il ici des recommandations pour l'ordre à mettre en œuvre en psychiatrie ? Les items HoNOS livrés sous forme de CHOP sont justement non spécifiques au diagnostic ou au traitement.
 {{<collapsibleBlock groupId="behandlungen">}}
 
-- Selon la description de la variable <br />
-Numéro unique attribué au traitement, dans l'ordre. <br />
-1 = traitement 1 <br />
-2 = traitement 2 <br />
-3 = traitement 3 <br />
-(…) etc. -> illimité <br />
+- Selon la description de la variable           
+Numéro unique attribué au traitement, dans l'ordre.             
+1 = traitement 1            
+2 = traitement 2            
+3 = traitement 3            
+(…) etc. -> illimité            
 Les critères suivants sont recommandés pour l'ordre des traitements :
-<ol>
-- Procédures de traitement du diagnostic principal 
-- Procédures de traitement des diagnostics supplémentaires 
-- Procédures de définition du diagnostic principal 
-- Procédures de définition des diagnostics supplémentaires 
-- Autres procédures 
-</ol>
+1. Procédures de traitement du diagnostic principal 
+2. Procédures de traitement des diagnostics supplémentaires 
+3. Procédures de définition du diagnostic principal 
+4. Procédures de définition des diagnostics supplémentaires 
+5. Autres procédures 
 
--
-Pour les items HoNOS, nous recommandons une numérotation chronologique (mesures HoNOS antérieures = ID inférieures, mesures HoNOS ultérieures = ID supérieures).
-
-
+- Pour les items HoNOS, nous recommandons une numérotation chronologique (mesures HoNOS antérieures = ID inférieures, mesures HoNOS ultérieures = ID supérieures).
 {{</collapsibleBlock>}}
 
 2. Nous craignons un peu que, surtout dans les premiers temps, ces données ne soient pas entièrement saisies et qu'il y ait beaucoup de retouches. C'est pourquoi nous aimerions définir le champ comme obligatoire pour les codes CHOP concernés. Existe-t-il pour le catalogue CHOP une attribution des codes considérés comme opérationnels ou interventionnels ?

--- a/content/fr/FAQ/Falldaten/6_medikamente.md
+++ b/content/fr/FAQ/Falldaten/6_medikamente.md
@@ -10,9 +10,10 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="medikamente">}}
 
+{{<numberedList>}}
 1. Variable «medi_id»: Les numéros de prestations peuvent être alphanumériques chez nos clients, la variable n'est prévue que sous forme numérique. Serait-il également possible d'exporter ici le pharmacode ou le GTIN ?
 {{<collapsibleBlock groupId="medikamente">}}
 Cette variable a dû être ajoutée pour des raisons purement techniques (structure XML) et représente un numéro de ligne unique du tableau thématique "Médicaments". Tant que la variable est remplie de manière univoque et complète, il serait théoriquement possible d'indiquer un pharmacode ou un GTIN. L'OFS doute toutefois que ces conditions puissent être respectées pour tous les médicaments. Pour certains, ces informations ne sont tout simplement pas encore disponibles.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/6_medikamente.md
+++ b/content/fr/FAQ/Falldaten/6_medikamente.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="medikamente">}}
 
 1. Variable «medi_id»: Les numéros de prestations peuvent être alphanumériques chez nos clients, la variable n'est prévue que sous forme numérique. Serait-il également possible d'exporter ici le pharmacode ou le GTIN ?
@@ -14,3 +15,4 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="medikamente">}}
 Cette variable a dû être ajoutée pour des raisons purement techniques (structure XML) et représente un numéro de ligne unique du tableau thématique "Médicaments". Tant que la variable est remplie de manière univoque et complète, il serait théoriquement possible d'indiquer un pharmacode ou un GTIN. L'OFS doute toutefois que ces conditions puissent être respectées pour tous les médicaments. Pour certains, ces informations ne sont tout simplement pas encore disponibles.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/6_medikamente.md
+++ b/content/fr/FAQ/Falldaten/6_medikamente.md
@@ -11,9 +11,12 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="medikamente">}}
 
 {{<numberedList>}}
-1. Variable «medi_id»: Les numéros de prestations peuvent être alphanumériques chez nos clients, la variable n'est prévue que sous forme numérique. Serait-il également possible d'exporter ici le pharmacode ou le GTIN ?
+{{<listItem>}}
+Variable «medi_id»: Les numéros de prestations peuvent être alphanumériques chez nos clients, la variable n'est prévue que sous forme numérique. Serait-il également possible d'exporter ici le pharmacode ou le GTIN ?
 {{<collapsibleBlock groupId="medikamente">}}
 Cette variable a dû être ajoutée pour des raisons purement techniques (structure XML) et représente un numéro de ligne unique du tableau thématique "Médicaments". Tant que la variable est remplie de manière univoque et complète, il serait théoriquement possible d'indiquer un pharmacode ou un GTIN. L'OFS doute toutefois que ces conditions puissent être respectées pour tous les médicaments. Pour certains, ces informations ne sont tout simplement pas encore disponibles.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
 1. Une ligne est-elle exportée pour chaque facture émise - et chaque rémunération supplémentaire ?
@@ -20,3 +21,5 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 -	Le type de tarif, le montant et la quantité devraient être clairs. 
 -	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,7 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 
 2. Comment remplir les champs correspondants pour les factures qui ne sont pas facturées via SwissDRG, TARPSY ou ST Reha ?
 {{<collapsibleBlock groupId="rechnungen">}}
-
 -	En principe, selon la norme du Forum Datenaustausch, mais seulement pour les traitements hospitaliers. 
 -	Le type de tarif, le montant et la quantité devraient être clairs. 
 -	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
-
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -17,9 +17,11 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 
 2. Comment remplir les champs correspondants pour les factures qui ne sont pas facturées via SwissDRG, TARPSY ou ST Reha ?
 {{<collapsibleBlock groupId="rechnungen">}}
+{{<markdown>}}
 -	En principe, selon la norme du Forum Datenaustausch, mais seulement pour les traitements hospitaliers. 
 -	Le type de tarif, le montant et la quantité devraient être clairs. 
 -	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -11,12 +11,15 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="rechnungen">}}
 {{<numberedList>}}
 
-1. Une ligne est-elle exportée pour chaque facture émise - et chaque rémunération supplémentaire ?
+{{<listItem>}}
+Une ligne est-elle exportée pour chaque facture émise - et chaque rémunération supplémentaire ?
 {{<collapsibleBlock groupId="rechnungen">}}
 Il faut indiquer la même granularité que les lignes sur les factures envoyées. Si, par exemple, un forfait par cas ainsi qu'une rémunération supplémentaire ont été facturés pour un cas couvert par l'assurance de base et facturés à l'assurance de base et au canton, quatre lignes doivent être fournies (1.forfait au canton, 2.rémunération supplémentaire au canton, 3.forfait à l'assureur, 4.rémunération supplémentaire à l'assureur).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Comment remplir les champs correspondants pour les factures qui ne sont pas facturées via SwissDRG, TARPSY ou ST Reha ?
+{{<listItem>}}
+Comment remplir les champs correspondants pour les factures qui ne sont pas facturées via SwissDRG, TARPSY ou ST Reha ?
 {{<collapsibleBlock groupId="rechnungen">}}
 {{<markdown>}}
 -	En principe, selon la norme du Forum Datenaustausch, mais seulement pour les traitements hospitaliers. 
@@ -24,5 +27,7 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 -	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,9 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 
 2. Comment remplir les champs correspondants pour les factures qui ne sont pas facturées via SwissDRG, TARPSY ou ST Reha ?
 {{<collapsibleBlock groupId="rechnungen">}}
-<ul>
-<li>	En principe, selon la norme du Forum Datenaustausch, mais seulement pour les traitements hospitaliers. </li>
-<li>	Le type de tarif, le montant et la quantité devraient être clairs. </li>
-<li>	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. </li>
-</ul>
+
+-	En principe, selon la norme du Forum Datenaustausch, mais seulement pour les traitements hospitaliers. 
+-	Le type de tarif, le montant et la quantité devraient être clairs. 
+-	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
+
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Falldaten/7_rechnungen.md
+++ b/content/fr/FAQ/Falldaten/7_rechnungen.md
@@ -9,6 +9,7 @@ keywords: []
 
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="rechnungen">}}
+{{<numberedList>}}
 
 1. Une ligne est-elle exportée pour chaque facture émise - et chaque rémunération supplémentaire ?
 {{<collapsibleBlock groupId="rechnungen">}}
@@ -23,5 +24,5 @@ Il faut indiquer la même granularité que les lignes sur les factures envoyées
 -	Les champs qui n'ont pas de sens pour d'autres tarifs peuvent être laissés vides. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/fr/FAQ/Falldaten/8_patientenbewegung.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 1. L'entrée et la sortie sont-elles également considérées comme des épisodes ?
@@ -50,3 +51,5 @@ Oui, la date et l'heure doivent être fournies pour tous les épisodes, tant pou
 Oui, pour les traitements ambulatoires externes, le numéro REE du site de traitement peut être indiqué s'il est connu.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/fr/FAQ/Falldaten/8_patientenbewegung.md
@@ -11,46 +11,63 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 {{<numberedList>}}
-1. L'entrée et la sortie sont-elles également considérées comme des épisodes ?
+{{<listItem>}}
+L'entrée et la sortie sont-elles également considérées comme des épisodes ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 L'entrée et la sortie sont indiquées comme auparavant sous Date d’admission et Date de sortie. S’il n’y a pas d’autres mouvements, aucun épisode n'est saisi. Mais dès qu'il y a un mouvement devant être renseigné (par ex. une sortie intermédiaire), l'épisode 1 est saisi de la date d’admission à la sortie intermédiaire. L'épisode 2 commence à la sortie intermédiaire et se termine à la réadmission. L'épisode 3 commence à la réadmission et se termine au mouvement suivant (p. ex. vacances). Cela peut s’aboutir à plusieurs épisodes pour le même cas (voir illustration). Le dernier épisode (9) se termine à la date de sortie. Les épisodes sont les périodes précédant et suivant le changement de site d'un cas, les sorties / réadmissions intermédiaires, les traitements ambulatoires externes, les congés et les sorties d’essai.
 {{<insertImage image="Image3.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Un cas qui change de site est-il comptabilisé dans les deux sites ?
+{{<listItem>}}
+Un cas qui change de site est-il comptabilisé dans les deux sites ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Un cas est saisi une seule fois sous le site principal lorsqu'il est transféré d'un site à l'autre au sein d'un même hôpital (REE GESV).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Variables "wiedereintritt_aufenthalt" et "grund_wiedereintritt" : pourquoi ces indications ne peuvent-elles être fournies que pour A cas, alors que toutes les indications d'épisodes sont destinées aux cas ABC ?
+{{<listItem>}}
+Variables "wiedereintritt_aufenthalt" et "grund_wiedereintritt" : pourquoi ces indications ne peuvent-elles être fournies que pour A cas, alors que toutes les indications d'épisodes sont destinées aux cas ABC ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Des clarifications avec SwissDRG SA ont montré que les deux variables "wiedereintritt_aufenthalt" et "grund_wiedereintritt" peuvent être indiquées pour les cas statistiques ABC. Nous allons adapter cela dans la description des variables 1.4.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. episode_id : Nous sommes d'avis que pour notre clinique, il n'est pas nécessaire de distinguer des épisodes pour les cas hospitaliers, car nous n'enregistrons aucun changement de site au sein de l'hôpital. Est-ce bien compris de notre part ?
+{{<listItem>}}
+episode_id : Nous sommes d'avis que pour notre clinique, il n'est pas nécessaire de distinguer des épisodes pour les cas hospitaliers, car nous n'enregistrons aucun changement de site au sein de l'hôpital. Est-ce bien compris de notre part ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 La supposition est vraie en ce qui concerne les épisodes dus à des changements de lieu. Les épisodes dus à des sorties/réadmissions intermédiaires, à des congés, à des tests d'effort ou à des traitements ambulatoires extra-muros doivent toutefois être enregistrés.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Comprenons-nous bien que, par exemple, l'admission jusqu'au Traitements ambulatoires extra-muros est déjà un épisode ? Nous avons donc toujours un episode_art="1" entre les congés, les tests d'effort et les traitements à l'extérieur ?
+{{<listItem>}}
+Comprenons-nous bien que, par exemple, l'admission jusqu'au Traitements ambulatoires extra-muros est déjà un épisode ? Nous avons donc toujours un episode_art="1" entre les congés, les tests d'effort et les traitements à l'extérieur ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Correct
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Dans l'exemple (voir illustration ci-dessous), nous n'avons pas de changement de site au sein du même hôpital. Comprenons-nous bien que pour l'episode_art="1", il faut toujours indiquer le numéro REE site de l'hôpital ?
+{{<listItem>}}
+Dans l'exemple (voir illustration ci-dessous), nous n'avons pas de changement de site au sein du même hôpital. Comprenons-nous bien que pour l'episode_art="1", il faut toujours indiquer le numéro REE site de l'hôpital ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Correct
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. A notre connaissance, l'heure de retour d'un Traitements ambulatoires extra-muros n'est pas documentée. Il est toutefois possible que cela soit enregistré dans les systèmes d'information hospitaliers des hôpitaux. Cette indication est-elle obligatoire ?
+{{<listItem>}}
+A notre connaissance, l'heure de retour d'un Traitements ambulatoires extra-muros n'est pas documentée. Il est toutefois possible que cela soit enregistré dans les systèmes d'information hospitaliers des hôpitaux. Cette indication est-elle obligatoire ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Oui, la date et l'heure doivent être fournies pour tous les épisodes, tant pour le début que pour la fin. Si la fin d'un traitement ambulatoire extra-muros n'est pas saisie, nous recommandons de compléter cette saisie. Si cela n'est pas possible (aussi rapidement), nous recommandons d'utiliser une durée standard pour les tTraitements ambulatoires extra-muros.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. L'indication du BURNR de l'hôpital traitant à l'extérieur est facultative, n'est-ce pas ? 
+{{<listItem>}}
+L'indication du BURNR de l'hôpital traitant à l'extérieur est facultative, n'est-ce pas ? 
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Oui, pour les traitements ambulatoires externes, le numéro REE du site de traitement peut être indiqué s'il est connu.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/fr/FAQ/Falldaten/8_patientenbewegung.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
+{{<numberedList>}}
 1. L'entrée et la sortie sont-elles également considérées comme des épisodes ?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 L'entrée et la sortie sont indiquées comme auparavant sous Date d’admission et Date de sortie. S’il n’y a pas d’autres mouvements, aucun épisode n'est saisi. Mais dès qu'il y a un mouvement devant être renseigné (par ex. une sortie intermédiaire), l'épisode 1 est saisi de la date d’admission à la sortie intermédiaire. L'épisode 2 commence à la sortie intermédiaire et se termine à la réadmission. L'épisode 3 commence à la réadmission et se termine au mouvement suivant (p. ex. vacances). Cela peut s’aboutir à plusieurs épisodes pour le même cas (voir illustration). Le dernier épisode (9) se termine à la date de sortie. Les épisodes sont les périodes précédant et suivant le changement de site d'un cas, les sorties / réadmissions intermédiaires, les traitements ambulatoires externes, les congés et les sorties d’essai.
@@ -51,5 +52,5 @@ Oui, la date et l'heure doivent être fournies pour tous les épisodes, tant pou
 Oui, pour les traitements ambulatoires externes, le numéro REE du site de traitement peut être indiqué s'il est connu.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -23,7 +23,9 @@ Si l'établissement remplit SOMED, ces Coûts doivent être saisis dans SpiGes v
 3. Suppléments pour coûts unitaires ou coûts directs : Selon REKOLE®, des suppléments pour coûts unitaires ou coûts directs peuvent être saisis 
 sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables CUFI, il n'existe pas dans SpiGes et dans le jeu de données de coûts SwissDRG, contrairement aux coûts généraux, de variables CUFI séparées sur lesquelles les coûts d'utilisation des immobilisations peuvent être indiqués selon REKOLE. Dans ITAR_K, les comptes 400 et 401 doivent être indiqués sans suppléments CAN. Comment faut-il procéder avec ces suppléments CAN sur les comptes 400 et 401 ?
 {{<collapsibleBlock groupId="kostentraeger">}}
+{{<markdown>}}
 - Les suppléments de la CAN ne doivent pas être saisis dans les comptes 400 et 401. Ils doivent cependant être inclus dans les variables totales de la CAN (ktr_44_vkl / ktr_44_rekole). 
 - Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -11,17 +11,22 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 {{<numberedList>}}
-1. Comment faut-il présenter les coûts pour les cas forensiques C (durée de séjour de plusieurs années) ? Pour l'ensemble du cas (durée de séjour complète) ou seulement les coûts pour l'année civile concernée et le reste par le biais d’ajustements ?
+{{<listItem>}}
+Comment faut-il présenter les coûts pour les cas forensiques C (durée de séjour de plusieurs années) ? Pour l'ensemble du cas (durée de séjour complète) ou seulement les coûts pour l'année civile concernée et le reste par le biais d’ajustements ?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Pour les cas B et C, les coûts doivent être indiqués pour l'année civile ; pour les cas A,les coûts doivent être indiqués pour toute la durée du cas. Pour les payeurs ambulatoires et non liés à un cas, indiquer également les coûts sur l'année civile. Voir également la colonne «Indic. Temp» de la liste des variables.  
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Les cas de longue durée peuvent-ils être livrés dans SpiGes avec Type de CUFI 101=Longue durée comme unité finale d'imputation indépendante du cas, même si le SOMED est saisi en parallèle pour les soins de longue durée ?
+{{<listItem>}}
+Les cas de longue durée peuvent-ils être livrés dans SpiGes avec Type de CUFI 101=Longue durée comme unité finale d'imputation indépendante du cas, même si le SOMED est saisi en parallèle pour les soins de longue durée ?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Si l'établissement remplit SOMED, ces Coûts doivent être saisis dans SpiGes via le Type de UFI 101. Inversement, les cas individuels de longue durée en soins somatiques aigus et en réadaptation (patients en attente) doivent être représentés comme Type de CUFI 1 (=cas) et tarif 7 correspondant (=taxe de soins). Ainsi, l'ITAR_K et les statistiques sont corrects. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Suppléments pour coûts unitaires ou coûts directs : Selon REKOLE®, des suppléments pour coûts unitaires ou coûts directs peuvent être saisis 
+{{<listItem>}}
+Suppléments pour coûts unitaires ou coûts directs : Selon REKOLE®, des suppléments pour coûts unitaires ou coûts directs peuvent être saisis 
 sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables CUFI, il n'existe pas dans SpiGes et dans le jeu de données de coûts SwissDRG, contrairement aux coûts généraux, de variables CUFI séparées sur lesquelles les coûts d'utilisation des immobilisations peuvent être indiqués selon REKOLE. Dans ITAR_K, les comptes 400 et 401 doivent être indiqués sans suppléments CAN. Comment faut-il procéder avec ces suppléments CAN sur les comptes 400 et 401 ?
 {{<collapsibleBlock groupId="kostentraeger">}}
 {{<markdown>}}
@@ -29,5 +34,7 @@ sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables
 - Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 1. Comment faut-il présenter les coûts pour les cas forensiques C (durée de séjour de plusieurs années) ? Pour l'ensemble du cas (durée de séjour complète) ou seulement les coûts pour l'année civile concernée et le reste par le biais d’ajustements ?
@@ -25,3 +26,4 @@ sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables
 - Les suppléments de la CAN ne doivent pas être saisis dans les comptes 400 et 401. Ils doivent cependant être inclus dans les variables totales de la CAN (ktr_44_vkl / ktr_44_rekole). 
 - Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
+{{<numberedList>}}
 1. Comment faut-il présenter les coûts pour les cas forensiques C (durée de séjour de plusieurs années) ? Pour l'ensemble du cas (durée de séjour complète) ou seulement les coûts pour l'année civile concernée et le reste par le biais d’ajustements ?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Pour les cas B et C, les coûts doivent être indiqués pour l'année civile ; pour les cas A,les coûts doivent être indiqués pour toute la durée du cas. Pour les payeurs ambulatoires et non liés à un cas, indiquer également les coûts sur l'année civile. Voir également la colonne «Indic. Temp» de la liste des variables.  
@@ -28,4 +29,5 @@ sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables
 - Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -22,8 +22,6 @@ Si l'établissement remplit SOMED, ces Coûts doivent être saisis dans SpiGes v
 3. Suppléments pour coûts unitaires ou coûts directs : Selon REKOLE®, des suppléments pour coûts unitaires ou coûts directs peuvent être saisis 
 sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables CUFI, il n'existe pas dans SpiGes et dans le jeu de données de coûts SwissDRG, contrairement aux coûts généraux, de variables CUFI séparées sur lesquelles les coûts d'utilisation des immobilisations peuvent être indiqués selon REKOLE. Dans ITAR_K, les comptes 400 et 401 doivent être indiqués sans suppléments CAN. Comment faut-il procéder avec ces suppléments CAN sur les comptes 400 et 401 ?
 {{<collapsibleBlock groupId="kostentraeger">}}
-
 - Les suppléments de la CAN ne doivent pas être saisis dans les comptes 400 et 401. Ils doivent cependant être inclus dans les variables totales de la CAN (ktr_44_vkl / ktr_44_rekole). 
 - Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
-
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/fr/FAQ/Falldaten/9_kostentrager_fall.md
@@ -22,8 +22,8 @@ Si l'établissement remplit SOMED, ces Coûts doivent être saisis dans SpiGes v
 3. Suppléments pour coûts unitaires ou coûts directs : Selon REKOLE®, des suppléments pour coûts unitaires ou coûts directs peuvent être saisis 
 sur les coûts unitaires (besoins médicaux 400 et 401). Mais pour ces variables CUFI, il n'existe pas dans SpiGes et dans le jeu de données de coûts SwissDRG, contrairement aux coûts généraux, de variables CUFI séparées sur lesquelles les coûts d'utilisation des immobilisations peuvent être indiqués selon REKOLE. Dans ITAR_K, les comptes 400 et 401 doivent être indiqués sans suppléments CAN. Comment faut-il procéder avec ces suppléments CAN sur les comptes 400 et 401 ?
 {{<collapsibleBlock groupId="kostentraeger">}}
-<ul>
-<li> Les suppléments de la CAN ne doivent pas être saisis dans les comptes 400 et 401. Ils doivent cependant être inclus dans les variables totales de la CAN (ktr_44_vkl / ktr_44_rekole). </li>
-<li> Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. </li>
-</ul>
+
+- Les suppléments de la CAN ne doivent pas être saisis dans les comptes 400 et 401. Ils doivent cependant être inclus dans les variables totales de la CAN (ktr_44_vkl / ktr_44_rekole). 
+- Avec la version 1.4 de l'interface, la variable ktr_44_rekole est transformée de variable calculée en variable relevée (et ajoutée dans le XML), ce qui permet de relever un total ANK REKOLE® qui diffère de la somme des variables individuelles de la CUFI. 
+
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -37,7 +37,7 @@ J'ai déjà un CH-LOGIN, dois-je en créer un nouveau ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, vous pouvez utiliser votre CH-LOGIN. Vous devez toutefois mettre en place un deuxième facteur fort et y effectuer l'identification vidéo si cela n'a pas encore été fait sur votre CH-LOGIN.
 {{</collapsibleBlock>}}
-{{<listItem>}}
+{{</listItem>}}
 
 {{<listItem>}}
 Est-il possible de se connecter à AGOV pour l'application SpiGes ?

--- a/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
 1. Qu'est-ce qu'un deuxième facteur d'identification ?
@@ -33,3 +34,4 @@ Non, vous pouvez utiliser votre CH-LOGIN. Vous devez toutefois mettre en place u
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, pas pour le moment.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -11,29 +11,40 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
 {{<numberedList>}}
-1. Qu'est-ce qu'un deuxième facteur d'identification ?
+{{<listItem>}}
+Qu'est-ce qu'un deuxième facteur d'identification ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Le terme deuxième facteur d'identification fait référence à la caractéristique de sécurité que vous devez saisir en plus du premier facteur d'identification, qui est votre mot de passe CH-LOGIN.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Est-il possible d'avoir un seul CH-LOGIN pour l'entreprise/le site ? 
+{{<listItem>}}
+Est-il possible d'avoir un seul CH-LOGIN pour l'entreprise/le site ? 
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, le CH-LOGIN est personnel. Comme votre identité doit être vérifiée pour pouvoir accéder à la plateforme SpiGes, il est donc indispensable que votre compte soit personnel.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Il y a un changement de collaborateur/collaboratrice dans l'entreprise/le site, est-il possible de transférer le CH-LOGIN au nouveau collaborateur/à la nouvelle collaboratrice ?
+{{<listItem>}}
+Il y a un changement de collaborateur/collaboratrice dans l'entreprise/le site, est-il possible de transférer le CH-LOGIN au nouveau collaborateur/à la nouvelle collaboratrice ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, le CH-LOGIN est personnel. Comme votre identité doit être vérifiée pour pouvoir accéder à la plateforme SpiGes, il est donc indispensable que votre compte soit personnel. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. J'ai déjà un CH-LOGIN, dois-je en créer un nouveau ?
+{{<listItem>}}
+J'ai déjà un CH-LOGIN, dois-je en créer un nouveau ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, vous pouvez utiliser votre CH-LOGIN. Vous devez toutefois mettre en place un deuxième facteur fort et y effectuer l'identification vidéo si cela n'a pas encore été fait sur votre CH-LOGIN.
 {{</collapsibleBlock>}}
+{{<listItem>}}
 
-5. Est-il possible de se connecter à AGOV pour l'application SpiGes ?
+{{<listItem>}}
+Est-il possible de se connecter à AGOV pour l'application SpiGes ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, pas pour le moment.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/fr/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
+{{<numberedList>}}
 1. Qu'est-ce qu'un deuxième facteur d'identification ?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Le terme deuxième facteur d'identification fait référence à la caractéristique de sécurité que vous devez saisir en plus du premier facteur d'identification, qui est votre mot de passe CH-LOGIN.
@@ -34,4 +35,5 @@ Non, vous pouvez utiliser votre CH-LOGIN. Vous devez toutefois mettre en place u
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non, pas pour le moment.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 1. Quels sont les deuxièmes facteurs de sécurité que je peux utiliser ?
@@ -23,3 +24,4 @@ Oui. Sans l'identification vidéo, vous n'atteignez pas le niveau QoA 50 (Qualit
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Pour qu'une identité électronique puisse être considérée comme vérifiée, il faut qu'une pièce d'identité officielle du titulaire de l'identité électronique, munie d'une photo, ait été vérifiée, enregistrée et que le titulaire de l'identité électronique ait été correctement identifié. Pour ce faire, vous devez passer par cette procédure d'identification vidéo (VIPS) payante (CHF 45.00, par l'utilisateur final), au cours de laquelle votre identité est vérifiée par une personne certifiée.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -11,19 +11,26 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 {{<numberedList>}}
-1. Quels sont les deuxièmes facteurs de sécurité que je peux utiliser ?
+{{<listItem>}}
+Quels sont les deuxièmes facteurs de sécurité que je peux utiliser ?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Un deuxième facteur fort est nécessaire pour accéder à la plateforme SpiGes. Les deuxièmes facteurs suivants sont considérés comme forts : le Mobile ID et la clé FIDO. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. L'identification vidéo est-elle obligatoire pour l'utilisation de la plateforme de collecte de données SpiGes ?
+{{<listItem>}}
+L'identification vidéo est-elle obligatoire pour l'utilisation de la plateforme de collecte de données SpiGes ?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Oui. Sans l'identification vidéo, vous n'atteignez pas le niveau QoA 50 (Quality of Authentication) requis pour accéder à la plateforme d'enquête SpiGes. Pour atteindre ce niveau de qualité d'authentification, l'utilisateur doit disposer d'une identité électronique vérifiée et pas seulement d'une identité auto-enregistrée.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Qu'est-ce qu'une identité vérifiée et que faut-il faire pour l'obtenir ?
+{{<listItem>}}
+Qu'est-ce qu'une identité vérifiée et que faut-il faire pour l'obtenir ?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Pour qu'une identité électronique puisse être considérée comme vérifiée, il faut qu'une pièce d'identité officielle du titulaire de l'identité électronique, munie d'une photo, ait été vérifiée, enregistrée et que le titulaire de l'identité électronique ait été correctement identifié. Pour ce faire, vous devez passer par cette procédure d'identification vidéo (VIPS) payante (CHF 45.00, par l'utilisateur final), au cours de laquelle votre identité est vérifiée par une personne certifiée.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/fr/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
+{{<numberedList>}}
 1. Quels sont les deuxièmes facteurs de sécurité que je peux utiliser ?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Un deuxième facteur fort est nécessaire pour accéder à la plateforme SpiGes. Les deuxièmes facteurs suivants sont considérés comme forts : le Mobile ID et la clé FIDO. 
@@ -24,4 +25,5 @@ Oui. Sans l'identification vidéo, vous n'atteignez pas le niveau QoA 50 (Qualit
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Pour qu'une identité électronique puisse être considérée comme vérifiée, il faut qu'une pièce d'identité officielle du titulaire de l'identité électronique, munie d'une photo, ait été vérifiée, enregistrée et que le titulaire de l'identité électronique ait été correctement identifié. Pour ce faire, vous devez passer par cette procédure d'identification vidéo (VIPS) payante (CHF 45.00, par l'utilisateur final), au cours de laquelle votre identité est vérifiée par une personne certifiée.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
+{{<numberedList>}}
 1. Je n'ai pas de carte SIM suffisamment récente pour utiliser le Mobile ID, que puis-je faire ?
 {{<collapsibleBlock groupId="mobile_id">}}
 Vous pouvez commander une carte SIM de dernière génération auprès de votre opérateur téléphonique. Vous pouvez également utiliser une clé FIDO comme deuxième facteur de sécurité. 
@@ -29,4 +30,5 @@ Non. L'application Mobile ID n'est pas acceptée comme deuxième facteur de séc
 {{<collapsibleBlock groupId="mobile_id">}}
 Vous pouvez facilement vérifier si votre Mobile ID est actif en le testant sur le site Web Mobile ID. Ensuite, vous pouvez suivre les étapes pour l'ajouter à votre CH-LOGIN comme deuxième facteur de sécurité fort.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -11,24 +11,33 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 {{<numberedList>}}
-1. Je n'ai pas de carte SIM suffisamment récente pour utiliser le Mobile ID, que puis-je faire ?
+{{<listItem>}}
+Je n'ai pas de carte SIM suffisamment récente pour utiliser le Mobile ID, que puis-je faire ?
 {{<collapsibleBlock groupId="mobile_id">}}
 Vous pouvez commander une carte SIM de dernière génération auprès de votre opérateur téléphonique. Vous pouvez également utiliser une clé FIDO comme deuxième facteur de sécurité. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Que faire en cas de vol/perte du téléphone portable associé à la Mobile ID ?
+{{<listItem>}}
+Que faire en cas de vol/perte du téléphone portable associé à la Mobile ID ?
 {{<collapsibleBlock groupId="mobile_id">}}
 Faites bloquer votre carte SIM par votre opérateur de téléphonie mobile. Cela bloquera automatiquement votre Mobile ID. Dès que vous avez une nouvelle carte SIM, vous pouvez réactiver votre Mobile ID auprès de votre opérateur à l'aide du code de réactivation que vous avez reçu lors de l'activation de votre Mobile ID. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Puis-je utiliser l'application Mobile ID au lieu de l'activer avec la carte SIM ?
+{{<listItem>}}
+Puis-je utiliser l'application Mobile ID au lieu de l'activer avec la carte SIM ?
 {{<collapsibleBlock groupId="mobile_id">}}
 Non. L'application Mobile ID n'est pas acceptée comme deuxième facteur de sécurité fort pour votre CH-LOGIN. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. J'ai déjà un Mobile ID actif, que dois-je faire ?
+{{<listItem>}}
+J'ai déjà un Mobile ID actif, que dois-je faire ?
 {{<collapsibleBlock groupId="mobile_id">}}
 Vous pouvez facilement vérifier si votre Mobile ID est actif en le testant sur le site Web Mobile ID. Ensuite, vous pouvez suivre les étapes pour l'ajouter à votre CH-LOGIN comme deuxième facteur de sécurité fort.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/fr/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 1. Je n'ai pas de carte SIM suffisamment récente pour utiliser le Mobile ID, que puis-je faire ?
@@ -28,3 +29,4 @@ Non. L'application Mobile ID n'est pas acceptée comme deuxième facteur de séc
 {{<collapsibleBlock groupId="mobile_id">}}
 Vous pouvez facilement vérifier si votre Mobile ID est actif en le testant sur le site Web Mobile ID. Ensuite, vous pouvez suivre les étapes pour l'ajouter à votre CH-LOGIN comme deuxième facteur de sécurité fort.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="zugang">}}
 
+{{<numberedList>}}
 1. Le code d'embarquement expire-t-il après un certain temps ? Si oui, que dois-je faire si je n'ai pas pu m'inscrire à temps ? 
 {{<collapsibleBlock groupId="zugang">}}
 Demandez à la personne compétente de votre canton afin qu'elle puisse vous renvoyer un e-mail d’onboarding.
@@ -29,4 +30,5 @@ Votre premier interlocuteur est toujours le responsable de votre canton. Si vous
 {{<collapsibleBlock groupId="zugang">}}
 Non, il ne sera malheureusement pas possible d'utiliser d'autres identités électroniques que celle présentée. En effet, les autres identités électroniques ne présentent pas une qualité d'authentification suffisante pour l'utilisation de SpiGes.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="zugang">}}
 
 1. Le code d'embarquement expire-t-il après un certain temps ? Si oui, que dois-je faire si je n'ai pas pu m'inscrire à temps ? 
@@ -28,3 +29,4 @@ Votre premier interlocuteur est toujours le responsable de votre canton. Si vous
 {{<collapsibleBlock groupId="zugang">}}
 Non, il ne sera malheureusement pas possible d'utiliser d'autres identités électroniques que celle présentée. En effet, les autres identités électroniques ne présentent pas une qualité d'authentification suffisante pour l'utilisation de SpiGes.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/fr/FAQ/Onboarding_eIAM/4_zugang.md
@@ -11,24 +11,33 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="zugang">}}
 
 {{<numberedList>}}
-1. Le code d'embarquement expire-t-il après un certain temps ? Si oui, que dois-je faire si je n'ai pas pu m'inscrire à temps ? 
+{{<listItem>}}
+Le code d'embarquement expire-t-il après un certain temps ? Si oui, que dois-je faire si je n'ai pas pu m'inscrire à temps ? 
 {{<collapsibleBlock groupId="zugang">}}
 Demandez à la personne compétente de votre canton afin qu'elle puisse vous renvoyer un e-mail d’onboarding.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Que dois-je faire si je ne travaille plus à l'hôpital ? Puis-je supprimer mon profil ?
+{{<listItem>}}
+Que dois-je faire si je ne travaille plus à l'hôpital ? Puis-je supprimer mon profil ?
 {{<collapsibleBlock groupId="zugang">}}
 Si, suite à un changement de collaborateur, vous n'avez plus besoin d'accéder à la plateforme SpiGes ou si un changement de rôle/d'accès est nécessaire, vous devez impérativement vous annoncer à la personne compétente de votre canton afin qu'elle puisse vous retirer vos accès à la plateforme SpiGes. Votre compte CH-LOGIN et le deuxième facteur fort vérifié sont personnels, peuvent être utilisés pour d'autres applications de l'administration fédérale et ne sont pas supprimés.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. À qui puis-je m'adresser si mon login ne fonctionne pas ?
+{{<listItem>}}
+À qui puis-je m'adresser si mon login ne fonctionne pas ?
 {{<collapsibleBlock groupId="zugang">}}
 Votre premier interlocuteur est toujours le responsable de votre canton. Si vous ne trouvez pas ensemble de solution à votre problème, vous pouvez ensuite vous adresser à l'OFS.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. J'ai un autre type de compte de l'administration fédérale, peut-il être utilisé ?  
+{{<listItem>}}
+J'ai un autre type de compte de l'administration fédérale, peut-il être utilisé ?  
 {{<collapsibleBlock groupId="zugang">}}
 Non, il ne sera malheureusement pas possible d'utiliser d'autres identités électroniques que celle présentée. En effet, les autres identités électroniques ne présentent pas une qualité d'authentification suffisante pour l'utilisation de SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -16,10 +16,8 @@ En cas de questions professionnelles ou techniques concernant SpiGes, l'hôpital
 
 2. Quel sera à l'avenir le rôle des cantons, en particulier des partenaires cantonaux de l'enquête ?
 {{<collapsibleBlock groupId="roles">}}
-<ul>
-	<li> Les services cantonaux chargés de l'enquête collaborent au relevé de l'OFS comme jusqu'à présent (population de base, coordination et communication avec les hôpitaux, rappels, etc.). </li>
-	<li> L'office cantonal de la santé compétent libère désormais fin juillet les données des entreprises hospitalières situées sur son territoire pour une utilisation selon la LAMal sur la plateforme SpiGes. </li>
-</ul>
+- Les services cantonaux chargés de l'enquête collaborent au relevé de l'OFS comme jusqu'à présent (population de base, coordination et communication avec les hôpitaux, rappels, etc.).
+- L'office cantonal de la santé compétent libère désormais fin juillet les données des entreprises hospitalières situées sur son territoire pour une utilisation selon la LAMal sur la plateforme SpiGes.
 {{</collapsibleBlock>}}
 
 3. Il existe dans SpiGes des variables facultatives qui peuvent être remplies selon les directives du canton. Jusqu'à quand le canton doit-il communiquer aux établissements ou à l'OFS quelles variables doivent être remplies ? Le canton est-il libre de décider quels éléments facultatifs doivent être remplis ?

--- a/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="roles">}}
 
 1. Qui l'hôpital contacte-t-il s'il a des questions concernant le contenu de l'enquête SpiGes ?
@@ -40,3 +41,4 @@ L'OFS est en contact avec l'ANQ afin d'harmoniser les variables et les formats S
 Conformément à l'art. 23 de la loi fédérale du 18 mars 1994 sur l'assurance-maladie (LAMal ; RS 832.10), à l'art. 6 al. 4 de la loi du 9 octobre 1992 sur la statistique fédérale (LSF ; RS 431.01), à l'art. 6 al. 1 de l'ordonnance du 30 juin 1993 concernant l'exécution des relevés statistiques fédéraux (RS 431. 012.1) et aux dispositions relatives à la statistique des hôpitaux et à la statistique médicale annexées à ladite ordonnance, tous les hôpitaux sont tenus de fournir à l'Office fédéral de la statistique les données requises sous la forme prescrite et dans le délai fixé.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -11,37 +11,50 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="roles">}}
 
 {{<numberedList>}}
-1. Qui l'hôpital contacte-t-il s'il a des questions concernant le contenu de l'enquête SpiGes ?
+{{<listItem>}}
+Qui l'hôpital contacte-t-il s'il a des questions concernant le contenu de l'enquête SpiGes ?
 {{<collapsibleBlock groupId="roles">}}
 En cas de questions professionnelles ou techniques concernant SpiGes, l'hôpital s'adresse en premier lieu à son instance cantonale en charge du relevé.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Quel sera à l'avenir le rôle des cantons, en particulier des partenaires cantonaux de l'enquête ?
+{{<listItem>}}
+Quel sera à l'avenir le rôle des cantons, en particulier des partenaires cantonaux de l'enquête ?
 {{<collapsibleBlock groupId="roles">}}
 {{<markdown>}}
 - Les services cantonaux chargés de l'enquête collaborent au relevé de l'OFS comme jusqu'à présent (population de base, coordination et communication avec les hôpitaux, rappels, etc.).
 - L'office cantonal de la santé compétent libère désormais fin juillet les données des entreprises hospitalières situées sur son territoire pour une utilisation selon la LAMal sur la plateforme SpiGes.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Il existe dans SpiGes des variables facultatives qui peuvent être remplies selon les directives du canton. Jusqu'à quand le canton doit-il communiquer aux établissements ou à l'OFS quelles variables doivent être remplies ? Le canton est-il libre de décider quels éléments facultatifs doivent être remplis ?
+{{<listItem>}}
+Il existe dans SpiGes des variables facultatives qui peuvent être remplies selon les directives du canton. Jusqu'à quand le canton doit-il communiquer aux établissements ou à l'OFS quelles variables doivent être remplies ? Le canton est-il libre de décider quels éléments facultatifs doivent être remplis ?
 {{<collapsibleBlock groupId="roles">}}
 Les cantons communiquent à leurs hôpitaux la mise à disposition des variables facultatives (p. ex. op_gln) suffisamment tôt pour que celles-ci soient saisies dans le système d’information de l’hôpital à partir des données 2024. Le canton décide, conformément à ses directives dans le domaine de la santé, lesquelles peuvent être plus spécifiques que les directives nationales pour ces variables.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Les hôpitaux souhaitent qu'une séance d'information soit organisée afin de leur donner une meilleure vue d'ensemble des exigences à venir. Une telle réunion est-elle prévue par l’OFS ?
+{{<listItem>}}
+Les hôpitaux souhaitent qu'une séance d'information soit organisée afin de leur donner une meilleure vue d'ensemble des exigences à venir. Une telle réunion est-elle prévue par l’OFS ?
 {{<collapsibleBlock groupId="roles">}}
 L'OFS a déjà organisé 4 séances d'information pour un large public, auxquelles quelques hôpitaux ont également participé. H+ a informé ses hôpitaux à chaque fois. Etant donné qu'à l'heure actuelle, ce ne sont plus des questions conceptuelles qui se posent mais des thèmes très spécifiques, l'OFS ne considère pas qu'une telle manifestation soit l'instrument approprié. L'OFS rassemble les questions reçues et mettra en ligne la FAQ sur le site web de SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Est-ce que les exigences de l'ANQ pourront également être satisfaites à l'avenir avec le fichier XML ?
+{{<listItem>}}
+Est-ce que les exigences de l'ANQ pourront également être satisfaites à l'avenir avec le fichier XML ?
 {{<collapsibleBlock groupId="roles">}}
 L'OFS est en contact avec l'ANQ afin d'harmoniser les variables et les formats SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Est-ce que vous pourriez m’indiquer la base légale qui oblige les hôpitaux à transmettre la statistique ?
+{{<listItem>}}
+Est-ce que vous pourriez m’indiquer la base légale qui oblige les hôpitaux à transmettre la statistique ?
 {{<collapsibleBlock groupId="roles">}}
 Conformément à l'art. 23 de la loi fédérale du 18 mars 1994 sur l'assurance-maladie (LAMal ; RS 832.10), à l'art. 6 al. 4 de la loi du 9 octobre 1992 sur la statistique fédérale (LSF ; RS 431.01), à l'art. 6 al. 1 de l'ordonnance du 30 juin 1993 concernant l'exécution des relevés statistiques fédéraux (RS 431. 012.1) et aux dispositions relatives à la statistique des hôpitaux et à la statistique médicale annexées à ladite ordonnance, tous les hôpitaux sont tenus de fournir à l'Office fédéral de la statistique les données requises sous la forme prescrite et dans le délai fixé.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="roles">}}
 
+{{<numberedList>}}
 1. Qui l'hôpital contacte-t-il s'il a des questions concernant le contenu de l'enquête SpiGes ?
 {{<collapsibleBlock groupId="roles">}}
 En cas de questions professionnelles ou techniques concernant SpiGes, l'hôpital s'adresse en premier lieu à son instance cantonale en charge du relevé.
@@ -42,5 +43,5 @@ L'OFS est en contact avec l'ANQ afin d'harmoniser les variables et les formats S
 {{<collapsibleBlock groupId="roles">}}
 Conformément à l'art. 23 de la loi fédérale du 18 mars 1994 sur l'assurance-maladie (LAMal ; RS 832.10), à l'art. 6 al. 4 de la loi du 9 octobre 1992 sur la statistique fédérale (LSF ; RS 431.01), à l'art. 6 al. 1 de l'ordonnance du 30 juin 1993 concernant l'exécution des relevés statistiques fédéraux (RS 431. 012.1) et aux dispositions relatives à la statistique des hôpitaux et à la statistique médicale annexées à ladite ordonnance, tous les hôpitaux sont tenus de fournir à l'Office fédéral de la statistique les données requises sous la forme prescrite et dans le délai fixé.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/fr/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -17,8 +17,10 @@ En cas de questions professionnelles ou techniques concernant SpiGes, l'hôpital
 
 2. Quel sera à l'avenir le rôle des cantons, en particulier des partenaires cantonaux de l'enquête ?
 {{<collapsibleBlock groupId="roles">}}
+{{<markdown>}}
 - Les services cantonaux chargés de l'enquête collaborent au relevé de l'OFS comme jusqu'à présent (population de base, coordination et communication avec les hôpitaux, rappels, etc.).
 - L'office cantonal de la santé compétent libère désormais fin juillet les données des entreprises hospitalières situées sur son territoire pour une utilisation selon la LAMal sur la plateforme SpiGes.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Il existe dans SpiGes des variables facultatives qui peuvent être remplies selon les directives du canton. Jusqu'à quand le canton doit-il communiquer aux établissements ou à l'OFS quelles variables doivent être remplies ? Le canton est-il libre de décider quels éléments facultatifs doivent être remplis ?

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -71,14 +71,14 @@ D'autres exemples seraient la formation scolaire ou l'État civil. De notre poin
 {{<collapsibleBlock groupId="contenu">}}
 Dans l'esprit du "once only", nous avons intégré les listes de codes et les métadonnées dans un système OFS, qui sera ensuite publié. Les nouvelles listes de codes correspondent désormais au standard suisse de la plateforme d'interopérabilité i14y.admin.ch, alors qu'auparavant il s'agissait d'une solution spéciale MS.
 {{</collapsibleBlock>}}
-{{<listItem>}}
+{{</listItem>}}
 
 {{<listItem>}}
 Valeurs calculées : Dans la liste des variables, il y a quelques lignes qui sont grisées avec la remarque calculées (exemple uid). Cela signifie-t-il que nous les livrons vides dans le XML et que l'OFS les calculera et les inscrira ? Ou est-ce que nous ne fournissons pas ces valeurs et les ignorons ? 
 {{<collapsibleBlock groupId="contenu">}}
 Comme vous pouvez le constater dans le schéma XML, ces variables calculées ne sont pas incluses. Vous pouvez les ignorer.
 {{</collapsibleBlock>}}
-{{<listItem>}}
+{{</listItem>}}
 
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
+{{<numberedList>}}
 1. Quelles sont les variables qui changent avec SpiGes ?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
@@ -66,5 +67,5 @@ Dans l'esprit du "once only", nous avons intégré les listes de codes et les m�
 {{<collapsibleBlock groupId="contenu">}}
 Comme vous pouvez le constater dans le schéma XML, ces variables calculées ne sont pas incluses. Vous pouvez les ignorer.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quelles sont les variables qui changent avec SpiGes ?
@@ -58,3 +59,4 @@ Dans l'esprit du "once only", nous avons intégré les listes de codes et les m�
 Comme vous pouvez le constater dans le schéma XML, ces variables calculées ne sont pas incluses. Vous pouvez les ignorer.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -12,6 +12,7 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quelles sont les variables qui changent avec SpiGes ?
 {{<collapsibleBlock groupId="contenu">}}
+{{<markdown>}}
 - SpiGes a surtout des répercussions importantes sur le processus de contrôle des données et le format des données de la livraison. En ce qui concerne les données médicales (MS actuel), seuls quelques points changent. Les plus importants pour vous devraient être les suivants :
     - Le traitement principal est supprimé.
 	- Le complément au diagnostic principal est supprimé.
@@ -21,12 +22,15 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 	- La référence entre plusieurs diagnostics (dague/étoile, point d'exclamation) est désormais saisie avec une variable de référence (diagnose_zusatz) saisi à la place du caractère spécial.
 - La meilleure façon de suivre toutes les modifications apportées à l'ensemble de données ainsi que les détails exacts est de prendre la liste des variables et de filtrer la colonne "Nouveau/Variable MS" pour distinguer les nouvelles variables et les variables adaptées.
 - Les données de facturation et les coûts, respectivement les recettes, sont désormais collectées.
-- Vous trouverez ici le jeu de données complet : <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
+- Vous trouverez ici le jeu de données complet : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Quel est l'impact de SpiGes sur les directives de codage ?
 {{<collapsibleBlock groupId="contenu">}}
-Vous trouverez ces informations dans le manuel de codage. Celui-ci peut être téléchargé sous le lien suivant : <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html </a>
+{{<markdown>}}
+Vous trouverez ces informations dans le manuel de codage. Celui-ci peut être téléchargé sous le lien suivant : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Quel est le contenu du rapport national de vérification ?
@@ -36,13 +40,16 @@ Le contenu exact du rapport national de vérification dépend des contrôles qui
 
 4. Les hôpitaux pilotes seront en mesure de créer un premier jeu de données dès le printemps 2024. D'autres cantons exigent la remise d'un premier fichier de données XML d'ici septembre. Pour ces remises, attend-on des données réelles d'un système productif ou des données de test d'un système de test suffisent-elles ? En d'autres termes, la vraie analyse ne commencera-t-elle qu'en 2025 ou l'OFS veut-il déjà analyser les données réelles de 2024 ?
 {{<collapsibleBlock groupId="contenu">}}
+{{<markdown>}}
 - Pour le pilote au printemps 2024, on attend des hôpitaux pilotes qu'ils fournissent des données réelles issues d'un système productif. Celles-ci ne seront analysées que dans le but d'acquérir des connaissances sur le pilote. 
 - En août 2024, tous les hôpitaux (dans tous les cantons) devront effectuer un test d'interface afin de montrer que la mise en œuvre technique de l'interface fonctionne. Pour cela, des livraisons partielles, même à partir de systèmes de test, suffisent.
 - A partir du 1er janvier 2025, tous les hôpitaux devront fournir des données réelles de l'année 2024 issues des systèmes productifs et les vérifier intégralement avant fin avril et les justifier le cas échéant.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. Valeurs inversées : Nous avons remarqué que les valeurs de certaines variables sont différentes de celles des statistiques MS.       
-Par exemple, il y a la valeur des signes vitaux.        
+Par exemple, il y a la valeur des signes vitaux.
+{{<markdown>}}        
 Statistiques sur la MS :        
 0 = mort-né         
 1 = né vivant.      
@@ -50,6 +57,7 @@ Spiges (exactement l'inverse) :
 0 = naissance vivante        
 1 = mort-né.        
 D'autres exemples seraient la formation scolaire ou l'État civil. De notre point de vue, ce n'est pas optimal et nous aimerions savoir si c'est l'intention et, si oui, pourquoi ? 
+{{</markdown>}}
 {{<collapsibleBlock groupId="contenu">}}
 Dans l'esprit du "once only", nous avons intégré les listes de codes et les métadonnées dans un système OFS, qui sera ensuite publié. Les nouvelles listes de codes correspondent désormais au standard suisse de la plateforme d'interopérabilité i14y.admin.ch, alors qu'auparavant il s'agissait d'une solution spéciale MS.
 {{</collapsibleBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,7 +11,8 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 {{<numberedList>}}
-1. Quelles sont les variables qui changent avec SpiGes ?
+{{<listItem>}}
+Quelles sont les variables qui changent avec SpiGes ?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 - SpiGes a surtout des répercussions importantes sur le processus de contrôle des données et le format des données de la livraison. En ce qui concerne les données médicales (MS actuel), seuls quelques points changent. Les plus importants pour vous devraient être les suivants :
@@ -26,20 +27,26 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 - Vous trouverez ici le jeu de données complet : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Quel est l'impact de SpiGes sur les directives de codage ?
+{{<listItem>}}
+Quel est l'impact de SpiGes sur les directives de codage ?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 Vous trouverez ces informations dans le manuel de codage. Celui-ci peut être téléchargé sous le lien suivant : [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medkk.html).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Quel est le contenu du rapport national de vérification ?
+{{<listItem>}}
+Quel est le contenu du rapport national de vérification ?
 {{<collapsibleBlock groupId="contenu">}}
 Le contenu exact du rapport national de vérification dépend des contrôles qui sont actuellement élaborés avec un groupe de travail comprenant toutes les parties prenantes. Pour l'essentiel, le rapport national de vérification comprend les contrôles positifs ainsi que les justifications officielles de ces contrôles (un extrait du chat relatif au contrôle).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Les hôpitaux pilotes seront en mesure de créer un premier jeu de données dès le printemps 2024. D'autres cantons exigent la remise d'un premier fichier de données XML d'ici septembre. Pour ces remises, attend-on des données réelles d'un système productif ou des données de test d'un système de test suffisent-elles ? En d'autres termes, la vraie analyse ne commencera-t-elle qu'en 2025 ou l'OFS veut-il déjà analyser les données réelles de 2024 ?
+{{<listItem>}}
+Les hôpitaux pilotes seront en mesure de créer un premier jeu de données dès le printemps 2024. D'autres cantons exigent la remise d'un premier fichier de données XML d'ici septembre. Pour ces remises, attend-on des données réelles d'un système productif ou des données de test d'un système de test suffisent-elles ? En d'autres termes, la vraie analyse ne commencera-t-elle qu'en 2025 ou l'OFS veut-il déjà analyser les données réelles de 2024 ?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 - Pour le pilote au printemps 2024, on attend des hôpitaux pilotes qu'ils fournissent des données réelles issues d'un système productif. Celles-ci ne seront analysées que dans le but d'acquérir des connaissances sur le pilote. 
@@ -47,8 +54,10 @@ Le contenu exact du rapport national de vérification dépend des contrôles qui
 - A partir du 1er janvier 2025, tous les hôpitaux devront fournir des données réelles de l'année 2024 issues des systèmes productifs et les vérifier intégralement avant fin avril et les justifier le cas échéant.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Valeurs inversées : Nous avons remarqué que les valeurs de certaines variables sont différentes de celles des statistiques MS.       
+{{<listItem>}}
+Valeurs inversées : Nous avons remarqué que les valeurs de certaines variables sont différentes de celles des statistiques MS.       
 Par exemple, il y a la valeur des signes vitaux.
 {{<markdown>}}        
 Statistiques sur la MS :        
@@ -62,10 +71,14 @@ D'autres exemples seraient la formation scolaire ou l'État civil. De notre poin
 {{<collapsibleBlock groupId="contenu">}}
 Dans l'esprit du "once only", nous avons intégré les listes de codes et les métadonnées dans un système OFS, qui sera ensuite publié. Les nouvelles listes de codes correspondent désormais au standard suisse de la plateforme d'interopérabilité i14y.admin.ch, alors qu'auparavant il s'agissait d'une solution spéciale MS.
 {{</collapsibleBlock>}}
+{{<listItem>}}
 
-6. Valeurs calculées : Dans la liste des variables, il y a quelques lignes qui sont grisées avec la remarque calculées (exemple uid). Cela signifie-t-il que nous les livrons vides dans le XML et que l'OFS les calculera et les inscrira ? Ou est-ce que nous ne fournissons pas ces valeurs et les ignorons ? 
+{{<listItem>}}
+Valeurs calculées : Dans la liste des variables, il y a quelques lignes qui sont grisées avec la remarque calculées (exemple uid). Cela signifie-t-il que nous les livrons vides dans le XML et que l'OFS les calculera et les inscrira ? Ou est-ce que nous ne fournissons pas ces valeurs et les ignorons ? 
 {{<collapsibleBlock groupId="contenu">}}
 Comme vous pouvez le constater dans le schéma XML, ces variables calculées ne sont pas incluses. Vous pouvez les ignorer.
 {{</collapsibleBlock>}}
+{{<listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/fr/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,25 +11,16 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quelles sont les variables qui changent avec SpiGes ?
 {{<collapsibleBlock groupId="contenu">}}
-<ul>
-<li> SpiGes a surtout des répercussions importantes sur le processus de contrôle des données et le format des données de la livraison. En ce qui concerne les données médicales (MS actuel), seuls quelques points changent. Les plus importants pour vous devraient être les suivants :
-<ul>
-<li> Le traitement principal est supprimé. </li>
-<li>	Le complément au diagnostic principal est supprimé. </li>
-<li>	Les diagnostics et les traitements peuvent désormais être saisis en nombre illimité. </li>
-<li>	Le temps de prestation chirurgicale est saisi pour les procédures chirurgicales.</li>
-<li>	Le début du traitement doit être saisi avec l'heure (de l'opération dans son ensemble) pour les procédures chirurgicales.   </li>
-<li>	La référence entre plusieurs diagnostics (dague/étoile, point d'exclamation) est désormais saisie avec une variable de référence (diagnose_zusatz) saisi à la place du caractère spécial. </li>
-</ul>
-</li>
-
-<li>	La meilleure façon de suivre toutes les modifications apportées à l'ensemble de données ainsi que les détails exacts est de prendre la liste des variables et de filtrer la colonne "Nouveau/Variable MS" pour distinguer les nouvelles variables et les variables adaptées. </li>
-
-<li> Les données de facturation et les coûts, respectivement les recettes, sont désormais collectées. </li>
-
-<li> Vous trouverez ici le jeu de données complet :   <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
-</li>
-</ul>
+- SpiGes a surtout des répercussions importantes sur le processus de contrôle des données et le format des données de la livraison. En ce qui concerne les données médicales (MS actuel), seuls quelques points changent. Les plus importants pour vous devraient être les suivants :
+    - Le traitement principal est supprimé.
+	- Le complément au diagnostic principal est supprimé.
+	- Les diagnostics et les traitements peuvent désormais être saisis en nombre illimité. 
+	- Le temps de prestation chirurgicale est saisi pour les procédures chirurgicales.
+	- Le début du traitement doit être saisi avec l'heure (de l'opération dans son ensemble) pour les procédures chirurgicales. 
+	- La référence entre plusieurs diagnostics (dague/étoile, point d'exclamation) est désormais saisie avec une variable de référence (diagnose_zusatz) saisi à la place du caractère spécial.
+- La meilleure façon de suivre toutes les modifications apportées à l'ensemble de données ainsi que les détails exacts est de prendre la liste des variables et de filtrer la colonne "Nouveau/Variable MS" pour distinguer les nouvelles variables et les variables adaptées.
+- Les données de facturation et les coûts, respectivement les recettes, sont désormais collectées.
+- Vous trouverez ici le jeu de données complet : <a href="https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/gesundheitswesen/projekt-spiges.assetdetail.25885643.html </a>
 {{</collapsibleBlock>}}
 
 2. Quel est l'impact de SpiGes sur les directives de codage ?
@@ -44,11 +35,9 @@ Le contenu exact du rapport national de vérification dépend des contrôles qui
 
 4. Les hôpitaux pilotes seront en mesure de créer un premier jeu de données dès le printemps 2024. D'autres cantons exigent la remise d'un premier fichier de données XML d'ici septembre. Pour ces remises, attend-on des données réelles d'un système productif ou des données de test d'un système de test suffisent-elles ? En d'autres termes, la vraie analyse ne commencera-t-elle qu'en 2025 ou l'OFS veut-il déjà analyser les données réelles de 2024 ?
 {{<collapsibleBlock groupId="contenu">}}
-<ul>
-<li> Pour le pilote au printemps 2024, on attend des hôpitaux pilotes qu'ils fournissent des données réelles issues d'un système productif. Celles-ci ne seront analysées que dans le but d'acquérir des connaissances sur le pilote.  </li>
-<li> En août 2024, tous les hôpitaux (dans tous les cantons) devront effectuer un test d'interface afin de montrer que la mise en œuvre technique de l'interface fonctionne. Pour cela, des livraisons partielles, même à partir de systèmes de test, suffisent. </li>
-<li> A partir du 1er janvier 2025, tous les hôpitaux devront fournir des données réelles de l'année 2024 issues des systèmes productifs et les vérifier intégralement avant fin avril et les justifier le cas échéant. </li>
-</ul>
+- Pour le pilote au printemps 2024, on attend des hôpitaux pilotes qu'ils fournissent des données réelles issues d'un système productif. Celles-ci ne seront analysées que dans le but d'acquérir des connaissances sur le pilote. 
+- En août 2024, tous les hôpitaux (dans tous les cantons) devront effectuer un test d'interface afin de montrer que la mise en œuvre technique de l'interface fonctionne. Pour cela, des livraisons partielles, même à partir de systèmes de test, suffisent.
+- A partir du 1er janvier 2025, tous les hôpitaux devront fournir des données réelles de l'année 2024 issues des systèmes productifs et les vérifier intégralement avant fin avril et les justifier le cas échéant.
 {{</collapsibleBlock>}}
 
 5. Valeurs inversées : Nous avons remarqué que les valeurs de certaines variables sont différentes de celles des statistiques MS.       

--- a/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="GGH">}}
 
+{{<numberedList>}}
 1. Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
@@ -72,5 +73,5 @@ Un centre de prestations est une unité organisationnelle de l'hôpital dans laq
 {{<collapsibleBlock groupId="GGH">}}
 Oui, un cas est toujours enregistré sur un seul site, et ce sur le site principal (cf. variable burnr).
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -12,16 +12,20 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Lors de la première enquête SpiGes (données 2024) en 2025, la population KS est encore importée manuellement sous forme de listes Excel.
 - L'actuel «REE» s'appellera «REEGESV» et restera l'identifiant de l'hôpital. Le «REE de site» s'appellera «REE» à partir des données 2024 (relevé 2025).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Quelle est la différence entre une entreprise hospitalière, un hôpital et un site hospitalier ?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Une entreprise hospitalière est une entreprise dont le code NOGA est 861001 (hôpitaux généraux), 861002 (cliniques spécialisées) ou 869004 (maisons de naissance). Elle est désignée de manière univoque par le numéro d'identification IDENT.
 - Dans le relevé SpiGes, l'hôpital est une unité qui remplit un ITAR_K et sur lequel se base la définition de cas de SwissDRG SA. Un hôpital est identifié par le n° REE GESV qui n'est géré que sur la base de données de GESV.
 - Un site hospitalier est clairement identifié par le numéro REE et appartient toujours à une seule entreprise hospitalière.
 Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 12 hôpitaux (REEGESV) et 14 sites (REE) :
+{{</markdown>}}
 {{<insertImage image="tableauFAQ1_fr.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
 
@@ -53,8 +57,10 @@ Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 1
 
 4. Comment déterminer à quel hôpital (REEGESV) appartient un site (REE) ?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Nous demandons l'attribution des sites (REE) aux hôpitaux (REEGESV) lors de la collecte de la population de base. Dans ce processus, ce sont les cantons, en collaboration avec les hôpitaux, qui nous donnent l’information.
 - Le burnr_gesv est également relevé à la demande de nos partenaires.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. Qu'est-ce qu'un centre de prestations principal (p. ex. M000, M050) ?

--- a/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,15 +11,18 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="GGH">}}
 
 {{<numberedList>}}
-1. Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
+{{<listItem>}}
+Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Lors de la première enquête SpiGes (données 2024) en 2025, la population KS est encore importée manuellement sous forme de listes Excel.
 - L'actuel «REE» s'appellera «REEGESV» et restera l'identifiant de l'hôpital. Le «REE de site» s'appellera «REE» à partir des données 2024 (relevé 2025).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Quelle est la différence entre une entreprise hospitalière, un hôpital et un site hospitalier ?
+{{<listItem>}}
+Quelle est la différence entre une entreprise hospitalière, un hôpital et un site hospitalier ?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Une entreprise hospitalière est une entreprise dont le code NOGA est 861001 (hôpitaux généraux), 861002 (cliniques spécialisées) ou 869004 (maisons de naissance). Elle est désignée de manière univoque par le numéro d'identification IDENT.
@@ -29,8 +32,10 @@ Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 1
 {{</markdown>}}
 {{<insertImage image="tableauFAQ1_fr.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Quels sont les termes synonymes d'entreprise hospitalière, d'hôpital et de site hospitalier utilisés dans l'enquête SpiGes ?
+{{<listItem>}}
+Quels sont les termes synonymes d'entreprise hospitalière, d'hôpital et de site hospitalier utilisés dans l'enquête SpiGes ?
 {{<collapsibleBlock groupId="GGH">}}
 <table class="w-100">
   <tr>
@@ -55,23 +60,31 @@ Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 1
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Comment déterminer à quel hôpital (REEGESV) appartient un site (REE) ?
+{{<listItem>}}
+Comment déterminer à quel hôpital (REEGESV) appartient un site (REE) ?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Nous demandons l'attribution des sites (REE) aux hôpitaux (REEGESV) lors de la collecte de la population de base. Dans ce processus, ce sont les cantons, en collaboration avec les hôpitaux, qui nous donnent l’information.
 - Le burnr_gesv est également relevé à la demande de nos partenaires.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Qu'est-ce qu'un centre de prestations principal (p. ex. M000, M050) ?
+{{<listItem>}}
+Qu'est-ce qu'un centre de prestations principal (p. ex. M000, M050) ?
 {{<collapsibleBlock groupId="GGH">}}
 Un centre de prestations est une unité organisationnelle de l'hôpital dans laquelle sont fournies, entre autres, des prestations médicales, médico-techniques ou médico-thérapeutiques. L'enquête SpiGes indique dans quel centre de prestations médicales principal le patient est traité. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Si un hôpital a plusieurs sites, un cas est-il toujours enregistré sur un seul site, même s'il a été transféré d'un site vers un autre site du même hôpital ?
+{{<listItem>}}
+Si un hôpital a plusieurs sites, un cas est-il toujours enregistré sur un seul site, même s'il a été transféré d'un site vers un autre site du même hôpital ?
 {{<collapsibleBlock groupId="GGH">}}
 Oui, un cas est toujours enregistré sur un seul site, et ce sur le site principal (cf. variable burnr).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
@@ -65,3 +66,5 @@ Un centre de prestations est une unité organisationnelle de l'hôpital dans laq
 {{<collapsibleBlock groupId="GGH">}}
 Oui, un cas est toujours enregistré sur un seul site, et ce sur le site principal (cf. variable burnr).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/fr/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,19 +11,15 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1. Lors de l'introduction de SpiGes ou au moment de la définition de la population de base pour la première enquête SpiGes, travaille-t-on encore avec les «listes d'hôpitaux» traditionnelles ou déjà avec SpiReg ?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> Lors de la première enquête SpiGes (données 2024) en 2025, la population KS est encore importée manuellement sous forme de listes Excel. </li>
-<li> L'actuel «REE» s'appellera «REEGESV» et restera l'identifiant de l'hôpital. Le «REE de site» s'appellera «REE» à partir des données 2024 (relevé 2025). </li>
-</ul>
+- Lors de la première enquête SpiGes (données 2024) en 2025, la population KS est encore importée manuellement sous forme de listes Excel.
+- L'actuel «REE» s'appellera «REEGESV» et restera l'identifiant de l'hôpital. Le «REE de site» s'appellera «REE» à partir des données 2024 (relevé 2025).
 {{</collapsibleBlock>}}
 
 2. Quelle est la différence entre une entreprise hospitalière, un hôpital et un site hospitalier ?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> Une entreprise hospitalière est une entreprise dont le code NOGA est 861001 (hôpitaux généraux), 861002 (cliniques spécialisées) ou 869004 (maisons de naissance). Elle est désignée de manière univoque par le numéro d'identification IDENT. </li>
-<li> Dans le relevé SpiGes, l'hôpital est une unité qui remplit un ITAR_K et sur lequel se base la définition de cas de SwissDRG SA. Un hôpital est identifié par le n° REE GESV qui n'est géré que sur la base de données de GESV. </li>
-<li> Un site hospitalier est clairement identifié par le numéro REE et appartient toujours à une seule entreprise hospitalière. </li>
-</ul>
+- Une entreprise hospitalière est une entreprise dont le code NOGA est 861001 (hôpitaux généraux), 861002 (cliniques spécialisées) ou 869004 (maisons de naissance). Elle est désignée de manière univoque par le numéro d'identification IDENT.
+- Dans le relevé SpiGes, l'hôpital est une unité qui remplit un ITAR_K et sur lequel se base la définition de cas de SwissDRG SA. Un hôpital est identifié par le n° REE GESV qui n'est géré que sur la base de données de GESV.
+- Un site hospitalier est clairement identifié par le numéro REE et appartient toujours à une seule entreprise hospitalière.
 Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 12 hôpitaux (REEGESV) et 14 sites (REE) :
 {{<insertImage image="tableauFAQ1_fr.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
@@ -56,10 +52,8 @@ Le tableau suivant montre, à titre d'exemple, une entreprise (IDE/IDENT) avec 1
 
 4. Comment déterminer à quel hôpital (REEGESV) appartient un site (REE) ?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> Nous demandons l'attribution des sites (REE) aux hôpitaux (REEGESV) lors de la collecte de la population de base. Dans ce processus, ce sont les cantons, en collaboration avec les hôpitaux, qui nous donnent l’information. </li>
-<li> Le burnr_gesv est également relevé à la demande de nos partenaires. </li>
-</ul>
+- Nous demandons l'attribution des sites (REE) aux hôpitaux (REEGESV) lors de la collecte de la population de base. Dans ce processus, ce sont les cantons, en collaboration avec les hôpitaux, qui nous donnent l’information.
+- Le burnr_gesv est également relevé à la demande de nos partenaires.
 {{</collapsibleBlock>}}
 
 5. Qu'est-ce qu'un centre de prestations principal (p. ex. M000, M050) ?

--- a/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -11,40 +11,53 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 {{<numberedList>}}
-1. SpiGes ne collecte des informations que sur les cas stationnaires. Comment la partie ambulatoire d'ITAR_K® peut-elle être remplie ?
+{{<listItem>}}
+SpiGes ne collecte des informations que sur les cas stationnaires. Comment la partie ambulatoire d'ITAR_K® peut-elle être remplie ?
 {{<collapsibleBlock groupId="ITARK">}}
 L'ITAR_K® peut être établi avec les données SpiGes. Les données ambulatoires sont collectées dans les types d’UFI prévus à cet effet (p. ex. tarif laboratoire).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Comment l'ITAR_K® est-il établi par les cliniques qui ne font que partie d'une entreprise hospitalière ? (p.ex. la Clinique Sainte-Anne de Fribourg fait partie de Swiss Medical Network SA)
+{{<listItem>}}
+Comment l'ITAR_K® est-il établi par les cliniques qui ne font que partie d'une entreprise hospitalière ? (p.ex. la Clinique Sainte-Anne de Fribourg fait partie de Swiss Medical Network SA)
 {{<collapsibleBlock groupId="ITARK">}}
 La Clinique Sainte-Anne de Fribourg remplira la comptabilité financière (et toutes les autres données) dans la statistique des hôpitaux (KS) par clinique (niveau REEGESV). Les coûts issus de SpiGes peuvent être agrégés par REEGESV.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Les données sur les coûts doivent être saisies avant le 31 mars. Ces données doivent-elles avoir été révisées ? Actuellement, nous ne pourrions pas le faire, car les comptes annuels ne sont révisés que fin mars.
+{{<listItem>}}
+Les données sur les coûts doivent être saisies avant le 31 mars. Ces données doivent-elles avoir été révisées ? Actuellement, nous ne pourrions pas le faire, car les comptes annuels ne sont révisés que fin mars.
 {{<collapsibleBlock groupId="ITARK">}}
 A cette date, les données de coûts doivent avoir été vérifiées automatiquement pour la première fois sur la plateforme SpiGes. La révision des comptes peut avoir lieu plus tard.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Nous ne trouvons pas la variable SpiGes qui permettrait de diriger les recettes/coûts PIG directement liés à un cas vers la colonne « PIG » de ITAR_K®. Comment sera-t-il possible de reconstituer la colonne PIG de ITAR_K® à travers SpiGes?
+{{<listItem>}}
+Nous ne trouvons pas la variable SpiGes qui permettrait de diriger les recettes/coûts PIG directement liés à un cas vers la colonne « PIG » de ITAR_K®. Comment sera-t-il possible de reconstituer la colonne PIG de ITAR_K® à travers SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 - En ce qui concerne la représentation des prestations d'intérêt général, SpiGes s'en tient en principe à la jurisprudence et aux recommandations de l'association des hôpitaux H+. REKOLE® prévoit que les coûts des prestations d'intérêt général liées à un cas soient représentés sur le cas, mais que les produits soient représentés sur une unité finale d’imputation PIG séparé. Les coûts et les produits des PIG indépendants des cas sont également représentés sur une unité finale d’imputation PIG séparé.
 - D'un point de vue technique, il est toutefois possible de s'écarter des prescriptions de REKOLE®. Les coûts et les recettes des PIG liés aux cas peuvent également être saisis sur une unité finale d’imputation propre (type KTR 700-799). Cela est également laissé à l'appréciation du canton. Dans ce cas, il est important que les coûts et les produits pour les prestations AOS soient tout de même saisis sur le cas (type KTR = 1).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. ITAR_K peut être rempli au niveau de l'entreprise ou du site. Qu'est-ce qui est demandé dans SpiGes ? La décision en la matière revient-elle aux cantons ?
+{{<listItem>}}
+ITAR_K peut être rempli au niveau de l'entreprise ou du site. Qu'est-ce qui est demandé dans SpiGes ? La décision en la matière revient-elle aux cantons ?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 - ITAR_K est toujours rempli au niveau REE-GESV (BUR GESV), ce niveau doit correspondre au relevé de la KS. Le canton fournit les informations à ce sujet à l'OFS lors de la phase d’initialisation du relevé KS. Dans cette mesure, le canton a une influence. Il doit toutefois se concerter avec l'hôpital. 
 - L'ITAR_K est l'instrument de base pour les négociations tarifaires entre les hôpitaux et les Assureurs. La question de savoir si le canton participe à la détermination de la granularité dépend du fait qu'il s'agisse d'un hôpital répertorié, d'un hôpital conventionné ou d'un hôpital hors liste.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. A partir de quand l'ITAR_K® sera-t-il généré à partir de la plateforme SpiGes ?
+{{<listItem>}}
+A partir de quand l'ITAR_K® sera-t-il généré à partir de la plateforme SpiGes ?
 {{<collapsibleBlock groupId="ITARK">}}
 L'instrument ITAR_K® pour la tarification et l'examen de l'économicité devra être créé à l'avenir par SpiGes. Afin de garantir une transition sûre, ainsi que l'exactitude, il est prévu d'exploiter en parallèle l'ancienne et la nouvelle plateforme (H+ et SpiGes). En 2025 (données 2024), les ITAR_K® officiels seront encore établis par la plateforme H+ comme auparavant. A partir de septembre 2025, tous les hôpitaux auront en outre la possibilité d'établir les ITAR_K® 2025 (données 2024) via SpiGes et de comparer les deux résultats. Les éventuelles ambiguïtés pourront ainsi être levées avant l'introduction productive de l'établissement des ITAR_K® via SpiGes en 2026 (données 2025).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 1. SpiGes ne collecte des informations que sur les cas stationnaires. Comment la partie ambulatoire d'ITAR_K® peut-elle être remplie ?
@@ -40,3 +41,5 @@ A cette date, les données de coûts doivent avoir été vérifiées automatique
 {{<collapsibleBlock groupId="ITARK">}}
 L'instrument ITAR_K® pour la tarification et l'examen de l'économicité devra être créé à l'avenir par SpiGes. Afin de garantir une transition sûre, ainsi que l'exactitude, il est prévu d'exploiter en parallèle l'ancienne et la nouvelle plateforme (H+ et SpiGes). En 2025 (données 2024), les ITAR_K® officiels seront encore établis par la plateforme H+ comme auparavant. A partir de septembre 2025, tous les hôpitaux auront en outre la possibilité d'établir les ITAR_K® 2025 (données 2024) via SpiGes et de comparer les deux résultats. Les éventuelles ambiguïtés pourront ainsi être levées avant l'introduction productive de l'établissement des ITAR_K® via SpiGes en 2026 (données 2025).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -26,18 +26,14 @@ A cette date, les données de coûts doivent avoir été vérifiées automatique
 
 4. Nous ne trouvons pas la variable SpiGes qui permettrait de diriger les recettes/coûts PIG directement liés à un cas vers la colonne « PIG » de ITAR_K®. Comment sera-t-il possible de reconstituer la colonne PIG de ITAR_K® à travers SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li> En ce qui concerne la représentation des prestations d'intérêt général, SpiGes s'en tient en principe à la jurisprudence et aux recommandations de l'association des hôpitaux H+. REKOLE® prévoit que les coûts des prestations d'intérêt général liées à un cas soient représentés sur le cas, mais que les produits soient représentés sur une unité finale d’imputation PIG séparé. Les coûts et les produits des PIG indépendants des cas sont également représentés sur une unité finale d’imputation PIG séparé. </li>
-<li> D'un point de vue technique, il est toutefois possible de s'écarter des prescriptions de REKOLE®. Les coûts et les recettes des PIG liés aux cas peuvent également être saisis sur une unité finale d’imputation propre (type KTR 700-799). Cela est également laissé à l'appréciation du canton. Dans ce cas, il est important que les coûts et les produits pour les prestations AOS soient tout de même saisis sur le cas (type KTR = 1). </li>
-</ul>
+- En ce qui concerne la représentation des prestations d'intérêt général, SpiGes s'en tient en principe à la jurisprudence et aux recommandations de l'association des hôpitaux H+. REKOLE® prévoit que les coûts des prestations d'intérêt général liées à un cas soient représentés sur le cas, mais que les produits soient représentés sur une unité finale d’imputation PIG séparé. Les coûts et les produits des PIG indépendants des cas sont également représentés sur une unité finale d’imputation PIG séparé.
+- D'un point de vue technique, il est toutefois possible de s'écarter des prescriptions de REKOLE®. Les coûts et les recettes des PIG liés aux cas peuvent également être saisis sur une unité finale d’imputation propre (type KTR 700-799). Cela est également laissé à l'appréciation du canton. Dans ce cas, il est important que les coûts et les produits pour les prestations AOS soient tout de même saisis sur le cas (type KTR = 1).
 {{</collapsibleBlock>}}
 
 5. ITAR_K peut être rempli au niveau de l'entreprise ou du site. Qu'est-ce qui est demandé dans SpiGes ? La décision en la matière revient-elle aux cantons ?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li> ITAR_K est toujours rempli au niveau REE-GESV (BUR GESV), ce niveau doit correspondre au relevé de la KS. Le canton fournit les informations à ce sujet à l'OFS lors de la phase d’initialisation du relevé KS. Dans cette mesure, le canton a une influence. Il doit toutefois se concerter avec l'hôpital.  </li>
-<li> L'ITAR_K est l'instrument de base pour les négociations tarifaires entre les hôpitaux et les Assureurs. La question de savoir si le canton participe à la détermination de la granularité dépend du fait qu'il s'agisse d'un hôpital répertorié, d'un hôpital conventionné ou d'un hôpital hors liste. </li>
-</ul>
+- ITAR_K est toujours rempli au niveau REE-GESV (BUR GESV), ce niveau doit correspondre au relevé de la KS. Le canton fournit les informations à ce sujet à l'OFS lors de la phase d’initialisation du relevé KS. Dans cette mesure, le canton a une influence. Il doit toutefois se concerter avec l'hôpital. 
+- L'ITAR_K est l'instrument de base pour les négociations tarifaires entre les hôpitaux et les Assureurs. La question de savoir si le canton participe à la détermination de la granularité dépend du fait qu'il s'agisse d'un hôpital répertorié, d'un hôpital conventionné ou d'un hôpital hors liste.
 {{</collapsibleBlock>}}
 
 6. A partir de quand l'ITAR_K® sera-t-il généré à partir de la plateforme SpiGes ?

--- a/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="ITARK">}}
 
+{{<numberedList>}}
 1. SpiGes ne collecte des informations que sur les cas stationnaires. Comment la partie ambulatoire d'ITAR_K® peut-elle être remplie ?
 {{<collapsibleBlock groupId="ITARK">}}
 L'ITAR_K® peut être établi avec les données SpiGes. Les données ambulatoires sont collectées dans les types d’UFI prévus à cet effet (p. ex. tarif laboratoire).
@@ -45,5 +46,5 @@ A cette date, les données de coûts doivent avoir été vérifiées automatique
 {{<collapsibleBlock groupId="ITARK">}}
 L'instrument ITAR_K® pour la tarification et l'examen de l'économicité devra être créé à l'avenir par SpiGes. Afin de garantir une transition sûre, ainsi que l'exactitude, il est prévu d'exploiter en parallèle l'ancienne et la nouvelle plateforme (H+ et SpiGes). En 2025 (données 2024), les ITAR_K® officiels seront encore établis par la plateforme H+ comme auparavant. A partir de septembre 2025, tous les hôpitaux auront en outre la possibilité d'établir les ITAR_K® 2025 (données 2024) via SpiGes et de comparer les deux résultats. Les éventuelles ambiguïtés pourront ainsi être levées avant l'introduction productive de l'établissement des ITAR_K® via SpiGes en 2026 (données 2025).
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/fr/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -27,14 +27,18 @@ A cette date, les données de coûts doivent avoir été vérifiées automatique
 
 4. Nous ne trouvons pas la variable SpiGes qui permettrait de diriger les recettes/coûts PIG directement liés à un cas vers la colonne « PIG » de ITAR_K®. Comment sera-t-il possible de reconstituer la colonne PIG de ITAR_K® à travers SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 - En ce qui concerne la représentation des prestations d'intérêt général, SpiGes s'en tient en principe à la jurisprudence et aux recommandations de l'association des hôpitaux H+. REKOLE® prévoit que les coûts des prestations d'intérêt général liées à un cas soient représentés sur le cas, mais que les produits soient représentés sur une unité finale d’imputation PIG séparé. Les coûts et les produits des PIG indépendants des cas sont également représentés sur une unité finale d’imputation PIG séparé.
 - D'un point de vue technique, il est toutefois possible de s'écarter des prescriptions de REKOLE®. Les coûts et les recettes des PIG liés aux cas peuvent également être saisis sur une unité finale d’imputation propre (type KTR 700-799). Cela est également laissé à l'appréciation du canton. Dans ce cas, il est important que les coûts et les produits pour les prestations AOS soient tout de même saisis sur le cas (type KTR = 1).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. ITAR_K peut être rempli au niveau de l'entreprise ou du site. Qu'est-ce qui est demandé dans SpiGes ? La décision en la matière revient-elle aux cantons ?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 - ITAR_K est toujours rempli au niveau REE-GESV (BUR GESV), ce niveau doit correspondre au relevé de la KS. Le canton fournit les informations à ce sujet à l'OFS lors de la phase d’initialisation du relevé KS. Dans cette mesure, le canton a une influence. Il doit toutefois se concerter avec l'hôpital. 
 - L'ITAR_K est l'instrument de base pour les négociations tarifaires entre les hôpitaux et les Assureurs. La question de savoir si le canton participe à la détermination de la granularité dépend du fait qu'il s'agisse d'un hôpital répertorié, d'un hôpital conventionné ou d'un hôpital hors liste.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 6. A partir de quand l'ITAR_K® sera-t-il généré à partir de la plateforme SpiGes ?

--- a/content/fr/eIAM_Onboarding/_index.md
+++ b/content/fr/eIAM_Onboarding/_index.md
@@ -49,9 +49,9 @@ Exemple:
 <div class="left_col">
 <!-- First column content goes here -->
 <p> <ol>
-  <li> Dans cette colonne, vous voyez le EntID au niveau de l'entreprise et vous voyez le numéro Bur au niveau des sites hospitaliers. </li>
-  <li> Dans cette colonne, vous voyez le canton "administratif" de l'entreprise / du site hospitalier. </li>
-  <li> Dans cette colonne, vous voyez le canton géographique de l'entreprise / du site hospitalier. </li>
+  - Dans cette colonne, vous voyez le EntID au niveau de l'entreprise et vous voyez le numéro Bur au niveau des sites hospitaliers. 
+  - Dans cette colonne, vous voyez le canton "administratif" de l'entreprise / du site hospitalier. 
+  - Dans cette colonne, vous voyez le canton géographique de l'entreprise / du site hospitalier. 
 </ol> </p>
 
 <p> Vous voyez ici que le canton administratif et le canton géographique du site 1 ne sont pas les mêmes.  </p>

--- a/content/it/FAQ/2_identifikatoren.md
+++ b/content/it/FAQ/2_identifikatoren.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 1. Il NAVS è un campo obbligatorio. Tuttavia, ci saranno casi senza numero AVS. Dove è descritto cosa occorre indicare nella variabile in questo caso?
@@ -23,3 +24,5 @@ Al momento della trasmissione dei dati, gli identificatori e i dati vengono invi
 {{<collapsibleBlock groupId="identifikatoren">}}
 Durante la rilevazione il Cantone può esportare dati a scopi di plausibilizzazione; in questa fase il NAVS sarà pseudonimizzato.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/2_identifikatoren.md
+++ b/content/it/FAQ/2_identifikatoren.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
+{{<numberedList>}}
 1. Il NAVS è un campo obbligatorio. Tuttavia, ci saranno casi senza numero AVS. Dove è descritto cosa occorre indicare nella variabile in questo caso?
 {{<collapsibleBlock groupId="identifikatoren">}}
 La questione è ancora aperta. Nel set di dati è riportato: «Nota Bene: sono ancora in corso chiarimenti riguardo alle persone che non possono avere un numero AVS (v. anche la colonna "Da indicare per")». A breve termine, in questo caso si prevede di lasciare la variabile vuota o di indicare un numero dummy. Tuttavia, alcuni Cantoni confinanti con Paesi terzi si sono opposti con forza a questa soluzione, motivo per cui la questione sarà chiarita in modo più dettagliato nel lungo periodo.
@@ -24,5 +25,5 @@ Al momento della trasmissione dei dati, gli identificatori e i dati vengono invi
 {{<collapsibleBlock groupId="identifikatoren">}}
 Durante la rilevazione il Cantone può esportare dati a scopi di plausibilizzazione; in questa fase il NAVS sarà pseudonimizzato.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/2_identifikatoren.md
+++ b/content/it/FAQ/2_identifikatoren.md
@@ -11,19 +11,26 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="identifikatoren">}}
 
 {{<numberedList>}}
-1. Il NAVS è un campo obbligatorio. Tuttavia, ci saranno casi senza numero AVS. Dove è descritto cosa occorre indicare nella variabile in questo caso?
+{{<listItem>}}
+Il NAVS è un campo obbligatorio. Tuttavia, ci saranno casi senza numero AVS. Dove è descritto cosa occorre indicare nella variabile in questo caso?
 {{<collapsibleBlock groupId="identifikatoren">}}
 La questione è ancora aperta. Nel set di dati è riportato: «Nota Bene: sono ancora in corso chiarimenti riguardo alle persone che non possono avere un numero AVS (v. anche la colonna "Da indicare per")». A breve termine, in questo caso si prevede di lasciare la variabile vuota o di indicare un numero dummy. Tuttavia, alcuni Cantoni confinanti con Paesi terzi si sono opposti con forza a questa soluzione, motivo per cui la questione sarà chiarita in modo più dettagliato nel lungo periodo.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Per la rilevazione dei dati infatti bisognerebbe utilizzare il NAVS. Il NAVS, attraverso i partner tariffari, sarà visibile anche alle casse malati?
+{{<listItem>}}
+Per la rilevazione dei dati infatti bisognerebbe utilizzare il NAVS. Il NAVS, attraverso i partner tariffari, sarà visibile anche alle casse malati?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Al momento della trasmissione dei dati, gli identificatori e i dati vengono inviati separatamente. Il canale dei dati è criptato. Per il controllo dei NAVS viene utilizzato il «sistema di validazione UST NAVS». Una volta crittografato, il NAVS viene salvato nella banca dati sicura degli identificatori. Durante l’elaborazione dei dati sulla piattaforma, quindi, il NAVS è pseudonimizzato e non è salvato insieme al set di dati delle prestazioni. Il NAVS può essere trasmesso agli utenti dei dati solo in forma criptata. Dal momento che questi utenti dei dati non ne conoscono la chiave, per loro il NAVS è anonimizzato. Non è possibile risalire al numero originale.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Il Cantone ha accesso al file degli ID delle forniture?
+{{<listItem>}}
+Il Cantone ha accesso al file degli ID delle forniture?
 {{<collapsibleBlock groupId="identifikatoren">}}
 Durante la rilevazione il Cantone può esportare dati a scopi di plausibilizzazione; in questa fase il NAVS sarà pseudonimizzato.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
+{{<numberedList>}}
 1. Come possono essere registrati i costi e i ricavi delle prestazioni economicamente d’interesse generale (PEIG) in SpiGes?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Per la registrazione, selezionare il codice appropriato per le relative prestazioni PEIG sotto ktr_typ e inserire i relativi costi e ricavi utilizzando i numeri dei tipi di costo o dei centri di costo e i conti dei ricavi definiti in REKOLE®. In allegato l’elenco dei diversi tipi di PEG e il relativo codice ktr_typ:
@@ -116,6 +117,5 @@ Sì, è possibile. Sulla base dell’indicazione «ktr_typ» viene assegnate un�
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Per poter completare un ITAR_K, i costi dei casi ambulatoriali sono riassunti per tipo di KTR (ad esempio, tariffa per la dialisi).
 {{</collapsibleBlock>}}
-
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -106,7 +106,7 @@ Per la registrazione, selezionare il codice appropriato per le relative prestazi
 {{</listItem>}}
 
 {{<listItem>}}
-Le unità di imputazione indipendenti dal caso possono essere collegate a un ospedale (burnr_gesv) invece che a una sede? 
+Le unità di imputazione indipendenti dal caso possono essere collegate a un ospedale (burnr_gesv) invece che a una sede?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 No, non è possibile. 
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 1. Come possono essere registrati i costi e i ricavi delle prestazioni economicamente d’interesse generale (PEIG) in SpiGes?
@@ -117,3 +118,4 @@ Per poter completare un ITAR_K, i costi dei casi ambulatoriali sono riassunti pe
 {{</collapsibleBlock>}}
 
 
+{{</faqBlock>}}

--- a/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -11,7 +11,8 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="falldunabhangige">}}
 
 {{<numberedList>}}
-1. Come possono essere registrati i costi e i ricavi delle prestazioni economicamente d’interesse generale (PEIG) in SpiGes?
+{{<listItem>}}
+Come possono essere registrati i costi e i ricavi delle prestazioni economicamente d’interesse generale (PEIG) in SpiGes?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Per la registrazione, selezionare il codice appropriato per le relative prestazioni PEIG sotto ktr_typ e inserire i relativi costi e ricavi utilizzando i numeri dei tipi di costo o dei centri di costo e i conti dei ricavi definiti in REKOLE®. In allegato l’elenco dei diversi tipi di PEG e il relativo codice ktr_typ:
 <table class="w-100">
@@ -102,20 +103,28 @@ Per la registrazione, selezionare il codice appropriato per le relative prestazi
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Le unità di imputazione indipendenti dal caso possono essere collegate a un ospedale (burnr_gesv) invece che a una sede? 
+{{<listItem>}}
+Le unità di imputazione indipendenti dal caso possono essere collegate a un ospedale (burnr_gesv) invece che a una sede? 
 {{<collapsibleBlock groupId="falldunabhangige">}}
 No, non è possibile. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. I tipi UFI possono essere utilizzati più di una volta? Ad esempio, per 599 consegnare più righe con testo libero diverso nella variabile «ktr_beschr»?
+{{<listItem>}}
+I tipi UFI possono essere utilizzati più di una volta? Ad esempio, per 599 consegnare più righe con testo libero diverso nella variabile «ktr_beschr»?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Sì, è possibile. Sulla base dell’indicazione «ktr_typ» viene assegnate un’unità di imputazione di una colonna ITAR_K®. Ciò significa che nella variabile «ktr_typ» deve essere utilizzato uno dei valori predefiniti. Tuttavia, è possibile indicare più unità di imputazione con lo stesso tipo di UFI, ad esempio per ktr_typ 205 una volta con il testo libero «LAMal» e una volta con il testo libero «CTM» nella variabile «ktr_beschr». Queste due unità di imputazione vengono poi sommate e riportate nella colonna ITAR_K® «Ospedali di giorno psichiatria infantile e adolescenziale». In teoria, sono tecnicamente possibili anche altre suddivisioni, ad eccezione del caso ambulatoriale. Se hanno tutti lo stesso tipo UFI, vengono sommati e raffigurati come descritto. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. La parte KTR è prevista anche per i casi ambulatoriali o si riferisce esclusivamente ai casi di ricovero?
+{{<listItem>}}
+La parte KTR è prevista anche per i casi ambulatoriali o si riferisce esclusivamente ai casi di ricovero?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Per poter completare un ITAR_K, i costi dei casi ambulatoriali sono riassunti per tipo di KTR (ad esempio, tariffa per la dialisi).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
+++ b/content/it/FAQ/4_fallunabhängige_kosten_erlose.md
@@ -109,7 +109,6 @@ No, non è possibile.
 3. I tipi UFI possono essere utilizzati più di una volta? Ad esempio, per 599 consegnare più righe con testo libero diverso nella variabile «ktr_beschr»?
 {{<collapsibleBlock groupId="falldunabhangige">}}
 Sì, è possibile. Sulla base dell’indicazione «ktr_typ» viene assegnate un’unità di imputazione di una colonna ITAR_K®. Ciò significa che nella variabile «ktr_typ» deve essere utilizzato uno dei valori predefiniti. Tuttavia, è possibile indicare più unità di imputazione con lo stesso tipo di UFI, ad esempio per ktr_typ 205 una volta con il testo libero «LAMal» e una volta con il testo libero «CTM» nella variabile «ktr_beschr». Queste due unità di imputazione vengono poi sommate e riportate nella colonna ITAR_K® «Ospedali di giorno psichiatria infantile e adolescenziale». In teoria, sono tecnicamente possibili anche altre suddivisioni, ad eccezione del caso ambulatoriale. Se hanno tutti lo stesso tipo UFI, vengono sommati e raffigurati come descritto. 
-
 {{</collapsibleBlock>}}
 
 4. La parte KTR è prevista anche per i casi ambulatoriali o si riferisce esclusivamente ai casi di ricovero?

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
+{{<numberedList>}}
 1. Conosco il concetto di contabilità delle delimitazioni dalla piattaforma per la rilevazione dei dati ospedalieri (Spitaldatenerhebungsplattform, SDEP). Tale contabilità ci sarà anche in SpiGes o solo conformemente a ITAR_K®?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes utilizza il ponte di sintonizzazione della CDS / di REKOLE®.
@@ -72,5 +73,5 @@ I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispond
 Per ulteriori informazioni, consultare il manuale REKOLE® (capitolo 6.5.3).
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -65,9 +65,9 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
 
 5. Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispondono ai seguenti tipi di costi: <br />
-- 442 Ammortamenti <br />
-- 444 Altri canoni di locazione (compreso il leasing operativo) <br />
-- 448 Interessi calcolatori sull’attivo fisso <br />
+I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispondono ai seguenti tipi di costi:       
+- 442 Ammortamenti      
+- 444 Altri canoni di locazione (compreso il leasing operativo)       
+- 448 Interessi calcolatori sull’attivo fisso       
 Per ulteriori informazioni, consultare il manuale REKOLE® (capitolo 6.5.3).
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 1. Conosco il concetto di contabilità delle delimitazioni dalla piattaforma per la rilevazione dei dati ospedalieri (Spitaldatenerhebungsplattform, SDEP). Tale contabilità ci sarà anche in SpiGes o solo conformemente a ITAR_K®?
@@ -67,3 +68,5 @@ I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispond
 - 448 Interessi calcolatori sull’attivo fisso       
 Per ulteriori informazioni, consultare il manuale REKOLE® (capitolo 6.5.3).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -26,10 +26,10 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
 
 4. Per il 2024 (dati 2023), SwissDRG AG ha richiesto i dettagli dei costi di utilizzo delle immobilizzazioni dei casi secondo la OCPrere. In SpiGes, le variabili «_ank» consentono di inviare a REKOLE® i dettagli dei costi di utilizzo delle immobilizzazioni dei casi. Dal momento che SwissDRG AG ora necessita di questo dettaglio, non sarebbe opportuno in SpiGes prevedere la fornitura delle variabili «_ank» anche per i risultati OCPrere? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-<ul>
-<li> Si tratta solo di una rilevazione di prova da parte di SwissDRG AG. In caso di passaggio definitivo alla OCPrere, i costi di utilizzo delle immobilizzazioni per centro di costo in SpiGes verrebbero addebitati in base alla OCPrere anziché a REKOLE® e i costi di utilizzo delle immobilizzazioni di REKOLE® come totale. </li>
 
-<li> 	In sintesi, i costi di utilizzo delle immobilizzazioni devono essere rilevati secondo i seguenti metodi:
+- Si tratta solo di una rilevazione di prova da parte di SwissDRG AG. In caso di passaggio definitivo alla OCPrere, i costi di utilizzo delle immobilizzazioni per centro di costo in SpiGes verrebbero addebitati in base alla OCPrere anziché a REKOLE® e i costi di utilizzo delle immobilizzazioni di REKOLE® come totale. 
+
+- 	In sintesi, i costi di utilizzo delle immobilizzazioni devono essere rilevati secondo i seguenti metodi:
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variabili </div></th>
@@ -59,8 +59,8 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
     <td> REKOLE® </td>
   </tr>
 </table>
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 5. Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -27,8 +27,10 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
 
 4. Per il 2024 (dati 2023), SwissDRG AG ha richiesto i dettagli dei costi di utilizzo delle immobilizzazioni dei casi secondo la OCPrere. In SpiGes, le variabili «_ank» consentono di inviare a REKOLE® i dettagli dei costi di utilizzo delle immobilizzazioni dei casi. Dal momento che SwissDRG AG ora necessita di questo dettaglio, non sarebbe opportuno in SpiGes prevedere la fornitura delle variabili «_ank» anche per i risultati OCPrere? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
+{{<markdown>}}
 - Si tratta solo di una rilevazione di prova da parte di SwissDRG AG. In caso di passaggio definitivo alla OCPrere, i costi di utilizzo delle immobilizzazioni per centro di costo in SpiGes verrebbero addebitati in base alla OCPrere anziché a REKOLE® e i costi di utilizzo delle immobilizzazioni di REKOLE® come totale. 
 - In sintesi, i costi di utilizzo delle immobilizzazioni devono essere rilevati secondo i seguenti metodi:
+{{</markdown>}}
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variabili </div></th>
@@ -62,11 +64,13 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
 
 5. Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
+{{<markdown>}}
 I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispondono ai seguenti tipi di costi:       
 - 442 Ammortamenti      
 - 444 Altri canoni di locazione (compreso il leasing operativo)       
 - 448 Interessi calcolatori sull’attivo fisso       
 Per ulteriori informazioni, consultare il manuale REKOLE® (capitolo 6.5.3).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -11,22 +11,29 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="abstimmungsbrucke">}}
 
 {{<numberedList>}}
-1. Conosco il concetto di contabilità delle delimitazioni dalla piattaforma per la rilevazione dei dati ospedalieri (Spitaldatenerhebungsplattform, SDEP). Tale contabilità ci sarà anche in SpiGes o solo conformemente a ITAR_K®?
+{{<listItem>}}
+Conosco il concetto di contabilità delle delimitazioni dalla piattaforma per la rilevazione dei dati ospedalieri (Spitaldatenerhebungsplattform, SDEP). Tale contabilità ci sarà anche in SpiGes o solo conformemente a ITAR_K®?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 SpiGes utilizza il ponte di sintonizzazione della CDS / di REKOLE®.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. All’interno dell’UST, dove sono integrate le motivazioni delle delimitazioni? Come stanno le cose?
+{{<listItem>}}
+All’interno dell’UST, dove sono integrate le motivazioni delle delimitazioni? Come stanno le cose?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Le motivazioni vengono registrate a mo’ di verifica in SpiGes. In altre parole, se un importo secondo CoFi non corrisponde a quello secondo COAZ, occorre motivarne la differenza. Tali motivazioni vengono poi utilizzate anche altrove, ad esempio per il rapporto di verifica e per ITAR_K® o anche per il ponte di sintonizzazione della CDS.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Dove nel ponte di sintonizzazione vengono considerati i costi dei pazienti ospedalizzati a cavallo di due anni?
+{{<listItem>}}
+Dove nel ponte di sintonizzazione vengono considerati i costi dei pazienti ospedalizzati a cavallo di due anni?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 Nella contabilità per unità finali d’imputazione di SpiGes è possibile calcolare i costi dei pazienti dimessi nel corso dell’anno (casi A). Questi pazienti possono essere stati ammessi all’ospedale già nel corso degli anni precedenti e aver generato dei costi. Nella contabilità finanziaria gli oneri sono registrati per anno (calcolo temporale). La differenza risultante viene corretta nel ponte di sintonizzazione di SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Per il 2024 (dati 2023), SwissDRG AG ha richiesto i dettagli dei costi di utilizzo delle immobilizzazioni dei casi secondo la OCPrere. In SpiGes, le variabili «_ank» consentono di inviare a REKOLE® i dettagli dei costi di utilizzo delle immobilizzazioni dei casi. Dal momento che SwissDRG AG ora necessita di questo dettaglio, non sarebbe opportuno in SpiGes prevedere la fornitura delle variabili «_ank» anche per i risultati OCPrere? 
+{{<listItem>}}
+Per il 2024 (dati 2023), SwissDRG AG ha richiesto i dettagli dei costi di utilizzo delle immobilizzazioni dei casi secondo la OCPrere. In SpiGes, le variabili «_ank» consentono di inviare a REKOLE® i dettagli dei costi di utilizzo delle immobilizzazioni dei casi. Dal momento che SwissDRG AG ora necessita di questo dettaglio, non sarebbe opportuno in SpiGes prevedere la fornitura delle variabili «_ank» anche per i risultati OCPrere? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 - Si tratta solo di una rilevazione di prova da parte di SwissDRG AG. In caso di passaggio definitivo alla OCPrere, i costi di utilizzo delle immobilizzazioni per centro di costo in SpiGes verrebbero addebitati in base alla OCPrere anziché a REKOLE® e i costi di utilizzo delle immobilizzazioni di REKOLE® come totale. 
@@ -62,8 +69,10 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?
+{{<listItem>}}
+Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
 {{<markdown>}}
 I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispondono ai seguenti tipi di costi:       
@@ -73,5 +82,7 @@ I costi di utilizzo delle immobilizzazioni (secondo REKOLE® e OCPre) corrispond
 Per ulteriori informazioni, consultare il manuale REKOLE® (capitolo 6.5.3).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/5_abstimmungsbrucke.md
+++ b/content/it/FAQ/5_abstimmungsbrucke.md
@@ -26,10 +26,8 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
 
 4. Per il 2024 (dati 2023), SwissDRG AG ha richiesto i dettagli dei costi di utilizzo delle immobilizzazioni dei casi secondo la OCPrere. In SpiGes, le variabili «_ank» consentono di inviare a REKOLE® i dettagli dei costi di utilizzo delle immobilizzazioni dei casi. Dal momento che SwissDRG AG ora necessita di questo dettaglio, non sarebbe opportuno in SpiGes prevedere la fornitura delle variabili «_ank» anche per i risultati OCPrere? 
 {{<collapsibleBlock groupId="abstimmungsbrucke">}}
-
 - Si tratta solo di una rilevazione di prova da parte di SwissDRG AG. In caso di passaggio definitivo alla OCPrere, i costi di utilizzo delle immobilizzazioni per centro di costo in SpiGes verrebbero addebitati in base alla OCPrere anziché a REKOLE® e i costi di utilizzo delle immobilizzazioni di REKOLE® come totale. 
-
-- 	In sintesi, i costi di utilizzo delle immobilizzazioni devono essere rilevati secondo i seguenti metodi:
+- In sintesi, i costi di utilizzo delle immobilizzazioni devono essere rilevati secondo i seguenti metodi:
 <table class="w-100">
   <tr>
     <th style="width:65%"> Variabili </div></th>
@@ -59,8 +57,6 @@ Nella contabilità per unità finali d’imputazione di SpiGes è possibile calc
     <td> REKOLE® </td>
   </tr>
 </table>
-
-
 {{</collapsibleBlock>}}
 
 5. Il conto 441 non è incluso nel calcolo dei costi di utilizzo delle immobilizzazioni né dall’OCPre né da REKOLE®. Siete in grado di confermarlo?

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -92,10 +92,10 @@ Ci saranno diversi file di esportazione. Da un lato, sarà possibile esportare i
 
 7. Nel formato XML la sequenza delle variabili all’interno di una riga è determinante?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> La sequenza degli elementi è predefinita e non può essere modificata. Al massimo possono essere omessi degli elementi. Quindi, per l’elemento caso, i sottoelementi devono sempre essere inseriti nell’ordine «Amministrativo», «Neonati», «Psichiatria», «CUFI (caso)», «Diagnosi», «Trattamenti», «Medicamenti», «Fattura», «Trasferimento paziente» e «Dati cantonali». </li>
-<li> La sequenza dei singoli attributi da inserire nei campi può invece essere scelta liberamente. Ad esempio, nell’elemento «Amministrativo» si possono inserire attributi sia nella sequenza «...sesso=«2» età=«37»..» sia «...età=«37» sesso=«2»...». </li>
-</ul>
+
+- La sequenza degli elementi è predefinita e non può essere modificata. Al massimo possono essere omessi degli elementi. Quindi, per l’elemento caso, i sottoelementi devono sempre essere inseriti nell’ordine «Amministrativo», «Neonati», «Psichiatria», «CUFI (caso)», «Diagnosi», «Trattamenti», «Medicamenti», «Fattura», «Trasferimento paziente» e «Dati cantonali». 
+- La sequenza dei singoli attributi da inserire nei campi può invece essere scelta liberamente. Ad esempio, nell’elemento «Amministrativo» si possono inserire attributi sia nella sequenza «...sesso=«2» età=«37»..» sia «...età=«37» sesso=«2»...». 
+
 {{</collapsibleBlock>}}
 
 8. È anche possibile che il campo relativo a una variabile all’interno di una riga sia vuoto laddove la clinica non abbia nulla da inserire in quella riga per quella determinata variabile? Oppure in ogni riga devono sempre esse compilate tutte le variabili dell’interfaccia?
@@ -115,11 +115,11 @@ Un simile tool di test sarà messo a disposizione tramite API (Application Progr
 
 11. Si sa già quale sarà la procedura per quanto riguarda i dati cantonali aggiuntivi? Diversi Cantoni (ad es. LU, GR, VS e VD) dispongono già di una riga MK. Inoltre, anche i Cantoni di ZH e BE raccolgono dati aggiuntivi all’interno della piattaforma SDEP (Spitaldatenerhebungsplattform). Sapete già se questi dati saranno integrati nell’esportazione SpiGes o se dovranno essere esportati separatamente?
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> </li>
-<li> Sebbene i dati cantonali aggiuntivi possano essere indicati in XML, quando vengono importati sulla piattaforma SpiGes non vengono poi elaborati ulteriormente. I Cantoni ne verificano la plausibilità e li elaborano separatamente. </li>
-<li> 	La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. </li>
-</ul> 
+
+- I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
+- Sebbene i dati cantonali aggiuntivi possano essere indicati in XML, quando vengono importati sulla piattaforma SpiGes non vengono poi elaborati ulteriormente. I Cantoni ne verificano la plausibilità e li elaborano separatamente. 
+- 	La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. 
+ 
 {{</collapsibleBlock>}}
 
 12. Sarà possibile effettuare correzioni direttamente sulla piattaforma?
@@ -134,12 +134,12 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 
 14. Nuove variabili medi_id e rech_id: dalla descrizione non si capisce se si tratta di numeri sequenziali o di ID effettivi del sistema. Se sì, quale? Con medi_id abbiamo subito pensato all'ATC_Code, ma c'è una variabile in più per questo.  
 {{<collapsibleBlock groupId="technische_fragen">}}
-<ul>
-<li> Le due nuove variabili "medi_id" e "rech_id" sono 0  identificatori necessari per ragioni tecniche per una chiara assegnazione . Non devono necessariamente iniziare con 1, ma devono essere uniche per ogni caso. </li>
-<li> Il file XML di esempio 1.3, disponibile sulla nostra homepage all'indirizzo , contieneriporta anche un esempio. medi_id ="1" contiene l'informazione che si tratta del primo farmaco ad alto costo secondo le specifiche di SwissDRG AG per questo caso specifico. 
+
+- Le due nuove variabili "medi_id" e "rech_id" sono 0  identificatori necessari per ragioni tecniche per una chiara assegnazione . Non devono necessariamente iniziare con 1, ma devono essere uniche per ogni caso. 
+- Il file XML di esempio 1.3, disponibile sulla nostra homepage all'indirizzo , contieneriporta anche un esempio. medi_id ="1" contiene l'informazione che si tratta del primo farmaco ad alto costo secondo le specifiche di SwissDRG AG per questo caso specifico. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 15. Nei file di esempio per il file di identificazione e il file di dati, ci sono due campi per la versione. Tuttavia, queste versioni non corrispondono. La versione 1.0 è specificata nell'intestazione e la versione 1.3 nel tag aziendale. Perché i numeri di versione sono diversi? Come si fa a sapere quando specificare quale numero di versione?

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 1. C’è un modello di formato per l’importazione dei dati nell’applicazione SpiGes?
@@ -141,3 +142,5 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" è sempre in questo modo. La versione superiore si riferisce quindi all'"XML" stesso, mentre quella inferiore si riferisce all'XML specifico di SpiGes.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -92,10 +92,8 @@ Ci saranno diversi file di esportazione. Da un lato, sarà possibile esportare i
 
 7. Nel formato XML la sequenza delle variabili all’interno di una riga è determinante?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - La sequenza degli elementi è predefinita e non può essere modificata. Al massimo possono essere omessi degli elementi. Quindi, per l’elemento caso, i sottoelementi devono sempre essere inseriti nell’ordine «Amministrativo», «Neonati», «Psichiatria», «CUFI (caso)», «Diagnosi», «Trattamenti», «Medicamenti», «Fattura», «Trasferimento paziente» e «Dati cantonali». 
 - La sequenza dei singoli attributi da inserire nei campi può invece essere scelta liberamente. Ad esempio, nell’elemento «Amministrativo» si possono inserire attributi sia nella sequenza «...sesso=«2» età=«37»..» sia «...età=«37» sesso=«2»...». 
-
 {{</collapsibleBlock>}}
 
 8. È anche possibile che il campo relativo a una variabile all’interno di una riga sia vuoto laddove la clinica non abbia nulla da inserire in quella riga per quella determinata variabile? Oppure in ogni riga devono sempre esse compilate tutte le variabili dell’interfaccia?
@@ -115,11 +113,9 @@ Un simile tool di test sarà messo a disposizione tramite API (Application Progr
 
 11. Si sa già quale sarà la procedura per quanto riguarda i dati cantonali aggiuntivi? Diversi Cantoni (ad es. LU, GR, VS e VD) dispongono già di una riga MK. Inoltre, anche i Cantoni di ZH e BE raccolgono dati aggiuntivi all’interno della piattaforma SDEP (Spitaldatenerhebungsplattform). Sapete già se questi dati saranno integrati nell’esportazione SpiGes o se dovranno essere esportati separatamente?
 {{<collapsibleBlock groupId="technische_fragen">}}
-
 - I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
 - Sebbene i dati cantonali aggiuntivi possano essere indicati in XML, quando vengono importati sulla piattaforma SpiGes non vengono poi elaborati ulteriormente. I Cantoni ne verificano la plausibilità e li elaborano separatamente. 
-- 	La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. 
- 
+- La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. 
 {{</collapsibleBlock>}}
 
 12. Sarà possibile effettuare correzioni direttamente sulla piattaforma?
@@ -138,8 +134,6 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 - Le due nuove variabili "medi_id" e "rech_id" sono 0  identificatori necessari per ragioni tecniche per una chiara assegnazione . Non devono necessariamente iniziare con 1, ma devono essere uniche per ogni caso. 
 - Il file XML di esempio 1.3, disponibile sulla nostra homepage all'indirizzo , contieneriporta anche un esempio. medi_id ="1" contiene l'informazione che si tratta del primo farmaco ad alto costo secondo le specifiche di SwissDRG AG per questo caso specifico. 
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
-
-
 {{</collapsibleBlock>}}
 
 15. Nei file di esempio per il file di identificazione e il file di dati, ci sono due campi per la versione. Tuttavia, queste versioni non corrispondono. La versione 1.0 è specificata nell'intestazione e la versione 1.3 nel tag aziendale. Perché i numeri di versione sono diversi? Come si fa a sapere quando specificare quale numero di versione?

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
+{{<numberedList>}}
 1. C’è un modello di formato per l’importazione dei dati nell’applicazione SpiGes?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Sì, vanno utilizzati imperativamente i formati nel piano dell’interfaccia. 
@@ -149,5 +150,5 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" è sempre in questo modo. La versione superiore si riferisce quindi all'"XML" stesso, mentre quella inferiore si riferisce all'XML specifico di SpiGes.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -73,7 +73,9 @@ Nel gennaio 2023 abbiamo organizzato un evento informativo per il produttore KIS
 </table>
 È possibile presentare tutte queste tabelle come un unico file xml in SpiGes?
 {{<collapsibleBlock groupId="technische_fragen">}}
-La tabella 12 Identificatori personali deve essere fornita in un file separato (per motivi di protezione dei dati). Per le tabelle rimanenti viene definito un file diverso, che però supporta le forniture parziali. In teoria, è quindi possibile consegnare tutte le tabelle in un unico file XML come consegne parziali. Tuttavia, si sconsiglia questa soluzione, in quanto richiede una laboriosa armonizzazione delle varie tabelle (per garantire che le informazioni su tutti i casi siano disponibili in tutti i file). Informazioni più dettagliate su questo argomento sono disponibili nella descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes sul nostro sito web.  <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a>
+{{<markdown>}}
+La tabella 12 Identificatori personali deve essere fornita in un file separato (per motivi di protezione dei dati). Per le tabelle rimanenti viene definito un file diverso, che però supporta le forniture parziali. In teoria, è quindi possibile consegnare tutte le tabelle in un unico file XML come consegne parziali. Tuttavia, si sconsiglia questa soluzione, in quanto richiede una laboriosa armonizzazione delle varie tabelle (per garantire che le informazioni su tutti i casi siano disponibili in tutti i file). Informazioni più dettagliate su questo argomento sono disponibili nella descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes sul nostro sito web. [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 4. Esiste la possibilità per le piccole imprese di creare un file XML a partire da un file Excel (in cui viene inserita la CUFI)? C’è un fornitore che ha in programma di attuare questa soluzione?
@@ -93,8 +95,10 @@ Ci saranno diversi file di esportazione. Da un lato, sarà possibile esportare i
 
 7. Nel formato XML la sequenza delle variabili all’interno di una riga è determinante?
 {{<collapsibleBlock groupId="technische_fragen">}}
+{{<markdown>}}
 - La sequenza degli elementi è predefinita e non può essere modificata. Al massimo possono essere omessi degli elementi. Quindi, per l’elemento caso, i sottoelementi devono sempre essere inseriti nell’ordine «Amministrativo», «Neonati», «Psichiatria», «CUFI (caso)», «Diagnosi», «Trattamenti», «Medicamenti», «Fattura», «Trasferimento paziente» e «Dati cantonali». 
 - La sequenza dei singoli attributi da inserire nei campi può invece essere scelta liberamente. Ad esempio, nell’elemento «Amministrativo» si possono inserire attributi sia nella sequenza «...sesso=«2» età=«37»..» sia «...età=«37» sesso=«2»...». 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 8. È anche possibile che il campo relativo a una variabile all’interno di una riga sia vuoto laddove la clinica non abbia nulla da inserire in quella riga per quella determinata variabile? Oppure in ogni riga devono sempre esse compilate tutte le variabili dell’interfaccia?
@@ -114,9 +118,11 @@ Un simile tool di test sarà messo a disposizione tramite API (Application Progr
 
 11. Si sa già quale sarà la procedura per quanto riguarda i dati cantonali aggiuntivi? Diversi Cantoni (ad es. LU, GR, VS e VD) dispongono già di una riga MK. Inoltre, anche i Cantoni di ZH e BE raccolgono dati aggiuntivi all’interno della piattaforma SDEP (Spitaldatenerhebungsplattform). Sapete già se questi dati saranno integrati nell’esportazione SpiGes o se dovranno essere esportati separatamente?
 {{<collapsibleBlock groupId="technische_fragen">}}
-- I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html </a> 
+{{<markdown>}}
+- I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html)
 - Sebbene i dati cantonali aggiuntivi possano essere indicati in XML, quando vengono importati sulla piattaforma SpiGes non vengono poi elaborati ulteriormente. I Cantoni ne verificano la plausibilità e li elaborano separatamente. 
 - La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 12. Sarà possibile effettuare correzioni direttamente sulla piattaforma?
@@ -131,9 +137,10 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 
 14. Nuove variabili medi_id e rech_id: dalla descrizione non si capisce se si tratta di numeri sequenziali o di ID effettivi del sistema. Se sì, quale? Con medi_id abbiamo subito pensato all'ATC_Code, ma c'è una variabile in più per questo.  
 {{<collapsibleBlock groupId="technische_fragen">}}
-
+{{<markdown>}}
 - Le due nuove variabili "medi_id" e "rech_id" sono 0  identificatori necessari per ragioni tecniche per una chiara assegnazione . Non devono necessariamente iniziare con 1, ma devono essere uniche per ogni caso. 
 - Il file XML di esempio 1.3, disponibile sulla nostra homepage all'indirizzo , contieneriporta anche un esempio. medi_id ="1" contiene l'informazione che si tratta del primo farmaco ad alto costo secondo le specifiche di SwissDRG AG per questo caso specifico. 
+{{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
 

--- a/content/it/FAQ/6_technische_fragen.md
+++ b/content/it/FAQ/6_technische_fragen.md
@@ -11,17 +11,22 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="technische_fragen">}}
 
 {{<numberedList>}}
-1. C’è un modello di formato per l’importazione dei dati nell’applicazione SpiGes?
+{{<listItem>}}
+C’è un modello di formato per l’importazione dei dati nell’applicazione SpiGes?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Sì, vanno utilizzati imperativamente i formati nel piano dell’interfaccia. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. L’UST ha informato anche i grandi fornitori di software per l’amministrazione dei pazienti (SAP)? Stanno già sviluppando soluzioni software? Presumibilmente in futuro il file XML dovrebbe poter essere creato nel software per l’amministrazione dei pazienti.
+{{<listItem>}}
+L’UST ha informato anche i grandi fornitori di software per l’amministrazione dei pazienti (SAP)? Stanno già sviluppando soluzioni software? Presumibilmente in futuro il file XML dovrebbe poter essere creato nel software per l’amministrazione dei pazienti.
 {{<collapsibleBlock groupId="technische_fragen">}}
 Nel gennaio 2023 abbiamo organizzato un evento informativo per il produttore KIS (software per l’amministrazione dei pazienti). Era presente anche SAP. L’UST tiene costantemente informato questo gruppo sullo stato di avanzamento della piattaforma SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. In base all’elenco delle variabili 1.3 vi sono le seguenti tabelle:
+{{<listItem>}}
+In base all’elenco delle variabili 1.3 vi sono le seguenti tabelle:
 <table>
   <tr>
     <td> 1 </td>
@@ -78,46 +83,62 @@ Nel gennaio 2023 abbiamo organizzato un evento informativo per il produttore KIS
 La tabella 12 Identificatori personali deve essere fornita in un file separato (per motivi di protezione dei dati). Per le tabelle rimanenti viene definito un file diverso, che però supporta le forniture parziali. In teoria, è quindi possibile consegnare tutte le tabelle in un unico file XML come consegne parziali. Tuttavia, si sconsiglia questa soluzione, in quanto richiede una laboriosa armonizzazione delle varie tabelle (per garantire che le informazioni su tutti i casi siano disponibili in tutti i file). Informazioni più dettagliate su questo argomento sono disponibili nella descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes sul nostro sito web. [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Esiste la possibilità per le piccole imprese di creare un file XML a partire da un file Excel (in cui viene inserita la CUFI)? C’è un fornitore che ha in programma di attuare questa soluzione?
+{{<listItem>}}
+Esiste la possibilità per le piccole imprese di creare un file XML a partire da un file Excel (in cui viene inserita la CUFI)? C’è un fornitore che ha in programma di attuare questa soluzione?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Questa possibilità è attualmente al vaglio dell’UST.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. È previsto di mettere a disposizione un Excel per i costi indipendenti dai casi, in cui l’impresa possa compilare i costi indipendenti dai casi in formato Excel e poi esportarli in formato XML? 
+{{<listItem>}}
+È previsto di mettere a disposizione un Excel per i costi indipendenti dai casi, in cui l’impresa possa compilare i costi indipendenti dai casi in formato Excel e poi esportarli in formato XML? 
 {{<collapsibleBlock groupId="technische_fragen">}}
 La fornitura separata di diversi tipi di elementi XML è consentita. Ciò significa che i centri di costo indipendenti dai casi possono sempre essere consegnati in un file diverso da quello dei centri di costo dipendenti dai casi. Dobbiamo ancora chiarire se possiamo fornire un tool per trasformare i dati tratti da un file Excel.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Il file di esportazione SpiGes ha la stessa struttura del file che gli ospedali importano in SpiGes?
+{{<listItem>}}
+Il file di esportazione SpiGes ha la stessa struttura del file che gli ospedali importano in SpiGes?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Ci saranno diversi file di esportazione. Da un lato, sarà possibile esportare il file XML che gli ospedali importano, dall’altro sarà possibile esportare in un formato semplice (diversi file CSV). 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Nel formato XML la sequenza delle variabili all’interno di una riga è determinante?
+{{<listItem>}}
+Nel formato XML la sequenza delle variabili all’interno di una riga è determinante?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - La sequenza degli elementi è predefinita e non può essere modificata. Al massimo possono essere omessi degli elementi. Quindi, per l’elemento caso, i sottoelementi devono sempre essere inseriti nell’ordine «Amministrativo», «Neonati», «Psichiatria», «CUFI (caso)», «Diagnosi», «Trattamenti», «Medicamenti», «Fattura», «Trasferimento paziente» e «Dati cantonali». 
 - La sequenza dei singoli attributi da inserire nei campi può invece essere scelta liberamente. Ad esempio, nell’elemento «Amministrativo» si possono inserire attributi sia nella sequenza «...sesso=«2» età=«37»..» sia «...età=«37» sesso=«2»...». 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. È anche possibile che il campo relativo a una variabile all’interno di una riga sia vuoto laddove la clinica non abbia nulla da inserire in quella riga per quella determinata variabile? Oppure in ogni riga devono sempre esse compilate tutte le variabili dell’interfaccia?
+{{<listItem>}}
+È anche possibile che il campo relativo a una variabile all’interno di una riga sia vuoto laddove la clinica non abbia nulla da inserire in quella riga per quella determinata variabile? Oppure in ogni riga devono sempre esse compilate tutte le variabili dell’interfaccia?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Sì, è possibile che il campo relativo a una variabile venga lasciato vuoto. Alcune variabili, tuttavia, devono essere inserite imperativamente. Esse sono contrassegnate come «required» nel file di definizione XSD ("xs:attribute name="fall_id" use="required"). Aggiungeremo questa informazione anche all’elenco delle variabili.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-9. Le variabili prive di contenuto possono essere consegnate anche con un valore ZERO (ad es., righe CUFI complete con ZERI nelle variabili in cui non è presente nulla)? 
+{{<listItem>}}
+Le variabili prive di contenuto possono essere consegnate anche con un valore ZERO (ad es., righe CUFI complete con ZERI nelle variabili in cui non è presente nulla)? 
 {{<collapsibleBlock groupId="technische_fragen">}}
 Dipende dalle variabili. Per le variabili CUFI, è possibile compilare tutte le variabili con il valore «0». Tuttavia, le variabili vuote («») o i valori nulli (»ZERO») non sono ammessi. Se si desidera controllare questo aspetto in concreto, è possibile convalidare il file XML rispetto alla definizione XSD. A tal fine esistono online appositi strumenti gratuiti. Si noti che su tali piattaforme non è consentito caricare dati reali. Tuttavia, è possibile utilizzarle per controllare esempi di file fittizi. Anche la piattaforma SpiGes appronterà una convalida del genere. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10. Ci sarà un software di plausibilità simile a Medplaus che potrà essere utilizzato localmente all’interno degli ospedali prima del caricamento?
+{{<listItem>}}
+Ci sarà un software di plausibilità simile a Medplaus che potrà essere utilizzato localmente all’interno degli ospedali prima del caricamento?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Un simile tool di test sarà messo a disposizione tramite API (Application Programming Interfaces). Tuttavia, sarà pronto solo nel corso del prossimo anno. Fino ad allora, consigliamo di continuare a utilizzare MedPlaus. Ve ne sarà anche una versione per il 2024.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-11. Si sa già quale sarà la procedura per quanto riguarda i dati cantonali aggiuntivi? Diversi Cantoni (ad es. LU, GR, VS e VD) dispongono già di una riga MK. Inoltre, anche i Cantoni di ZH e BE raccolgono dati aggiuntivi all’interno della piattaforma SDEP (Spitaldatenerhebungsplattform). Sapete già se questi dati saranno integrati nell’esportazione SpiGes o se dovranno essere esportati separatamente?
+{{<listItem>}}
+Si sa già quale sarà la procedura per quanto riguarda i dati cantonali aggiuntivi? Diversi Cantoni (ad es. LU, GR, VS e VD) dispongono già di una riga MK. Inoltre, anche i Cantoni di ZH e BE raccolgono dati aggiuntivi all’interno della piattaforma SDEP (Spitaldatenerhebungsplattform). Sapete già se questi dati saranno integrati nell’esportazione SpiGes o se dovranno essere esportati separatamente?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - I dati cantonali aggiuntivi sono stati presi in considerazione nell’interfaccia; vedi la descrizione del file XML per l’importazione dei dati nella piattaforma SpiGes 1.3: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.html)
@@ -125,18 +146,24 @@ Un simile tool di test sarà messo a disposizione tramite API (Application Progr
 - La parte SpiGes dei dati SDEP sarà integrata nell’esportazione SpiGes e resa disponibile agli utenti dei dati secondo la LAMal dalla piattaforma SpiGes. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-12. Sarà possibile effettuare correzioni direttamente sulla piattaforma?
+{{<listItem>}}
+Sarà possibile effettuare correzioni direttamente sulla piattaforma?
 {{<collapsibleBlock groupId="technische_fragen">}}
 No, la piattaforma non offre la possibilità di inserire o correggere i dati. L’obiettivo è correggere gli errori alla fonte, cioè nei sistemi degli ospedali, in modo che le future esportazioni siano coerenti e che nelle prossime rilevazioni gli errori non si verifichino più
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-13. Nuovi formati: Ci sono nuovi formati. Ad esempio, per rech_betrag. Il formato è N10.2 Si presume che si riferisca alla specificazione delle cifre decimali. In questo caso, 2 cifre decimali e una lunghezza totale di 12. È corretto?
+{{<listItem>}}
+Nuovi formati: Ci sono nuovi formati. Ad esempio, per rech_betrag. Il formato è N10.2 Si presume che si riferisca alla specificazione delle cifre decimali. In questo caso, 2 cifre decimali e una lunghezza totale di 12. È corretto?
 {{<collapsibleBlock groupId="technische_fragen">}}
 Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la virgola (e quindi un massimo di 8 cifre prima della virgola).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-14. Nuove variabili medi_id e rech_id: dalla descrizione non si capisce se si tratta di numeri sequenziali o di ID effettivi del sistema. Se sì, quale? Con medi_id abbiamo subito pensato all'ATC_Code, ma c'è una variabile in più per questo.  
+{{<listItem>}}
+Nuove variabili medi_id e rech_id: dalla descrizione non si capisce se si tratta di numeri sequenziali o di ID effettivi del sistema. Se sì, quale? Con medi_id abbiamo subito pensato all'ATC_Code, ma c'è una variabile in più per questo.  
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<markdown>}}
 - Le due nuove variabili "medi_id" e "rech_id" sono 0  identificatori necessari per ragioni tecniche per una chiara assegnazione . Non devono necessariamente iniziare con 1, ma devono essere uniche per ogni caso. 
@@ -144,11 +171,15 @@ Non proprio. N10.2 indica un numero con un totale di 10 cifre, di cui 2 dopo la 
 {{</markdown>}}
 {{<insertImage image="Image5.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-15. Nei file di esempio per il file di identificazione e il file di dati, ci sono due campi per la versione. Tuttavia, queste versioni non corrispondono. La versione 1.0 è specificata nell'intestazione e la versione 1.3 nel tag aziendale. Perché i numeri di versione sono diversi? Come si fa a sapere quando specificare quale numero di versione?
+{{<listItem>}}
+Nei file di esempio per il file di identificazione e il file di dati, ci sono due campi per la versione. Tuttavia, queste versioni non corrispondono. La versione 1.0 è specificata nell'intestazione e la versione 1.3 nel tag aziendale. Perché i numeri di versione sono diversi? Come si fa a sapere quando specificare quale numero di versione?
 {{<collapsibleBlock groupId="technische_fragen">}}
 {{<insertImage image="Image6.jpg" class="edge max-w-90">}}
 "?xml version="1.0″" è sempre in questo modo. La versione superiore si riferisce quindi all'"XML" stesso, mentre quella inferiore si riferisce all'XML specifico di SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -17,8 +17,10 @@ Il consolidamento dei casi viene gestito in SpiGes secondo le linee guida di Swi
 
 2. case_id_ch: Chi genera questo numero di caso e viene memorizzato automaticamente in Opale (sistema IRP)? Finora siamo riusciti a generare automaticamente in Opale l'identificazione del caso in entrambi i file (dati UST e file dei costi dei casi).
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - Il numero di casi unici a livello svizzero è generato dalla piattaforma SpiGes. Quando i dati vengono esportati dalla piattaforma, questo case_id_ch è disponibile per gli utenti dei dati.
 - L'identificatore del caso, la variabile fall_id, è generato dagli ospedali. Il software ospedaliero (ad es. Opale) dovrebbe continuare ad avere questa funzione.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Ci sono variabili (ad esempio la ventilazione) in cui il riferimento temporale è "intero caso" o "anno di indagine". Nella maggior parte degli ospedali, tuttavia, questa voce non viene registrata sull'asse temporale, ma solo una volta sul caso. Anche nel precedente dataset MS, tali voci erano sempre fornite solo per i casi A. Come pensate di fornire i casi B/C per queste variabili?
@@ -29,8 +31,10 @@ In linea di principio, dovrebbe essere possibile fornire le informazioni, solo a
 
 4. Qual è la definizione di «trasferimento interno»?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - È il passaggio da un reparto (acuto, psichiatria, riabilitazione) a un altro dello stesso ospedale (burnr_gesv)
 - Oppure si riferisce ai cosiddetti «pazienti in attesa»
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. È possibile ottenere una definizione per il valore «7 = Rimpatrio»?
@@ -40,23 +44,29 @@ Rimpatrio di un paziente con residenza principale svizzera dall'estero alla Sviz
 
 6. Qual è la definizione per «trasferimento»? (ad es. i codici «5 = Trasferimento entro 24 ore» e «6 = Paziente ritrasferito» della variabile Modalità di ammissione)
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - La variabile Modalità di ammissione esisteva già nella MS e non ha subito modifiche nella piattaforma SpiGes. La differenza tra un trasferimento e un trasferimento interno, è che il primo non avviene all’interno dello stesso ospedale (BURGESV), ma tra ospedali diversi (due BURGESV diversi). La definizione si basa sui principi di SwissDRG AG, che potete trovare qui:  <a href="https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf"> https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf </a>
 - La seguente specifica è stata comunicata da SwissDRG AG per il tipo di ricovero "6=Retransfer": Per un ricovero ininterrotto in un altro ospedale per più di 18 giorni e ritorno all'ospedale di origine. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 7. Come vengono codificati i casi trasferiti dalla riabilitazione (tariffa ST-REHA) alla lungodegenza (tariffa «tasse per le cure») nella stessa struttura? Le variabili 1.2.V02 e 1.5.V03 non consentono di specificare «Lungodegenza, stesso stabilimento».
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 Questo era già così per la MS; il caso passa dalla riabilitazione alla SOMED (stesso stabilimento); il codice 2 contiene entrambe le opzioni (stesso stabilimento o altro stabilimento). Il caso deve essere codificato come segue:             
 austritt_aufenthalt: 2 = casa di cura           
 eintritt_aufenthalt: 84 = Reparto/Clinica di riabilitazione, stesso stabilimento
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ### Variabile «Wohnland»: 
 
 8. Nella descrizione delle variabili è menzionata una distinta ripartizione dei Paesi extraeuropei in regioni. Questo elenco esiste già o sarà pubblicato in futuro?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - La procedura e l'elenco sono gli stessi della statistica MS. Ecco il link per consultare l’elenco:  <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html </a>
 - È possibile inserire le regioni per i Paesi non europei, ma è anche possibile specificare i codici dei Paesi. Questo è già il caso per la statistica MS e non è cambiato. Il formato è alfanumerico e può quindi contenere sia numeri che lettere.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 ###	35.	Variabile "classe assicurativa": 
@@ -68,8 +78,10 @@ La formulazione è in realtà un po' contraddittoria. Si è ipotizzato che non c
 
 10.	Secondo la nostra amministrazione dei pazienti, è difficile ottenere le informazioni per i casi con "assicurazione Flex" e inserire "8 = altro".  Ci saranno problemi in seguito nelle analisi o quali effetti ci saranno sulle statistiche se non (o non possiamo) inserire "8=altro"?
 {{<collapsibleBlock groupId="admninistratives">}}
+{{<markdown>}}
 - I casi flex e tutti gli altri modelli assicurativi che stanno diventando sempre più popolari non sono davvero facili da mappare. Si tratta di una sfida per la classe assicurativa, ma non drammatica per le statistiche. In caso di dubbio, questi casi dovrebbero essere indicati come semi-privati.
 - La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -45,8 +45,8 @@ Rimpatrio di un paziente con residenza principale svizzera dall'estero alla Sviz
 
 7. Come vengono codificati i casi trasferiti dalla riabilitazione (tariffa ST-REHA) alla lungodegenza (tariffa «tasse per le cure») nella stessa struttura? Le variabili 1.2.V02 e 1.5.V03 non consentono di specificare «Lungodegenza, stesso stabilimento».
 {{<collapsibleBlock groupId="admninistratives">}}
-Questo era già così per la MS; il caso passa dalla riabilitazione alla SOMED (stesso stabilimento); il codice 2 contiene entrambe le opzioni (stesso stabilimento o altro stabilimento). Il caso deve essere codificato come segue: <br />
-austritt_aufenthalt: 2 = casa di cura <br />
+Questo era già così per la MS; il caso passa dalla riabilitazione alla SOMED (stesso stabilimento); il codice 2 contiene entrambe le opzioni (stesso stabilimento o altro stabilimento). Il caso deve essere codificato come segue:             
+austritt_aufenthalt: 2 = casa di cura           
 eintritt_aufenthalt: 84 = Reparto/Clinica di riabilitazione, stesso stabilimento
 {{</collapsibleBlock>}}
 

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -16,10 +16,8 @@ Il consolidamento dei casi viene gestito in SpiGes secondo le linee guida di Swi
 
 2. case_id_ch: Chi genera questo numero di caso e viene memorizzato automaticamente in Opale (sistema IRP)? Finora siamo riusciti a generare automaticamente in Opale l'identificazione del caso in entrambi i file (dati UST e file dei costi dei casi).
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> Il numero di casi unici a livello svizzero è generato dalla piattaforma SpiGes. Quando i dati vengono esportati dalla piattaforma, questo case_id_ch è disponibile per gli utenti dei dati. </li>
-<li> L'identificatore del caso, la variabile fall_id, è generato dagli ospedali. Il software ospedaliero (ad es. Opale) dovrebbe continuare ad avere questa funzione. </li>
-</ul>
+- Il numero di casi unici a livello svizzero è generato dalla piattaforma SpiGes. Quando i dati vengono esportati dalla piattaforma, questo case_id_ch è disponibile per gli utenti dei dati.
+- L'identificatore del caso, la variabile fall_id, è generato dagli ospedali. Il software ospedaliero (ad es. Opale) dovrebbe continuare ad avere questa funzione.
 {{</collapsibleBlock>}}
 
 3. Ci sono variabili (ad esempio la ventilazione) in cui il riferimento temporale è "intero caso" o "anno di indagine". Nella maggior parte degli ospedali, tuttavia, questa voce non viene registrata sull'asse temporale, ma solo una volta sul caso. Anche nel precedente dataset MS, tali voci erano sempre fornite solo per i casi A. Come pensate di fornire i casi B/C per queste variabili?
@@ -30,10 +28,8 @@ In linea di principio, dovrebbe essere possibile fornire le informazioni, solo a
 
 4. Qual è la definizione di «trasferimento interno»?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> È il passaggio da un reparto (acuto, psichiatria, riabilitazione) a un altro dello stesso ospedale (burnr_gesv) </li>
-<li> Oppure si riferisce ai cosiddetti «pazienti in attesa» </li>
-</ul>
+- È il passaggio da un reparto (acuto, psichiatria, riabilitazione) a un altro dello stesso ospedale (burnr_gesv)
+- Oppure si riferisce ai cosiddetti «pazienti in attesa»
 {{</collapsibleBlock>}}
 
 5. È possibile ottenere una definizione per il valore «7 = Rimpatrio»?
@@ -43,10 +39,8 @@ Rimpatrio di un paziente con residenza principale svizzera dall'estero alla Sviz
 
 6. Qual è la definizione per «trasferimento»? (ad es. i codici «5 = Trasferimento entro 24 ore» e «6 = Paziente ritrasferito» della variabile Modalità di ammissione)
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> 	La variabile Modalità di ammissione esisteva già nella MS e non ha subito modifiche nella piattaforma SpiGes. La differenza tra un trasferimento e un trasferimento interno, è che il primo non avviene all’interno dello stesso ospedale (BURGESV), ma tra ospedali diversi (due BURGESV diversi). La definizione si basa sui principi di SwissDRG AG, che potete trovare qui:  <a href="https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf"> https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf </a> </li>
-<li> La seguente specifica è stata comunicata da SwissDRG AG per il tipo di ricovero "6=Retransfer": Per un ricovero ininterrotto in un altro ospedale per più di 18 giorni e ritorno all'ospedale di origine.  </li>
-</ul>
+- La variabile Modalità di ammissione esisteva già nella MS e non ha subito modifiche nella piattaforma SpiGes. La differenza tra un trasferimento e un trasferimento interno, è che il primo non avviene all’interno dello stesso ospedale (BURGESV), ma tra ospedali diversi (due BURGESV diversi). La definizione si basa sui principi di SwissDRG AG, che potete trovare qui:  <a href="https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf"> https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf </a>
+- La seguente specifica è stata comunicata da SwissDRG AG per il tipo di ricovero "6=Retransfer": Per un ricovero ininterrotto in un altro ospedale per più di 18 giorni e ritorno all'ospedale di origine. 
 {{</collapsibleBlock>}}
 
 7. Come vengono codificati i casi trasferiti dalla riabilitazione (tariffa ST-REHA) alla lungodegenza (tariffa «tasse per le cure») nella stessa struttura? Le variabili 1.2.V02 e 1.5.V03 non consentono di specificare «Lungodegenza, stesso stabilimento».
@@ -60,10 +54,8 @@ eintritt_aufenthalt: 84 = Reparto/Clinica di riabilitazione, stesso stabilimento
 
 8. Nella descrizione delle variabili è menzionata una distinta ripartizione dei Paesi extraeuropei in regioni. Questo elenco esiste già o sarà pubblicato in futuro?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> La procedura e l'elenco sono gli stessi della statistica MS. Ecco il link per consultare l’elenco:  <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html </a> </li>
-<li> È possibile inserire le regioni per i Paesi non europei, ma è anche possibile specificare i codici dei Paesi. Questo è già il caso per la statistica MS e non è cambiato. Il formato è alfanumerico e può quindi contenere sia numeri che lettere. </li>
-</ul>
+- La procedura e l'elenco sono gli stessi della statistica MS. Ecco il link per consultare l’elenco:  <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html </a>
+- È possibile inserire le regioni per i Paesi non europei, ma è anche possibile specificare i codici dei Paesi. Questo è già il caso per la statistica MS e non è cambiato. Il formato è alfanumerico e può quindi contenere sia numeri che lettere.
 {{</collapsibleBlock>}}
 
 ###	35.	Variabile "classe assicurativa": 
@@ -75,8 +67,6 @@ La formulazione è in realtà un po' contraddittoria. Si è ipotizzato che non c
 
 10.	Secondo la nostra amministrazione dei pazienti, è difficile ottenere le informazioni per i casi con "assicurazione Flex" e inserire "8 = altro".  Ci saranno problemi in seguito nelle analisi o quali effetti ci saranno sulle statistiche se non (o non possiamo) inserire "8=altro"?
 {{<collapsibleBlock groupId="admninistratives">}}
-<ul>
-<li> I casi flex e tutti gli altri modelli assicurativi che stanno diventando sempre più popolari non sono davvero facili da mappare. Si tratta di una sfida per la classe assicurativa, ma non drammatica per le statistiche. In caso di dubbio, questi casi dovrebbero essere indicati come semi-privati. </li>
-<li> La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna. </li>
-</ul>
+- I casi flex e tutti gli altri modelli assicurativi che stanno diventando sempre più popolari non sono davvero facili da mappare. Si tratta di una sfida per la classe assicurativa, ma non drammatica per le statistiche. In caso di dubbio, questi casi dovrebbero essere indicati come semi-privati.
+- La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna.
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
 1. Nel dataset SpiGes sono previsti casi a parentesi (= casi accorpati)? Nel campo della psichiatria, l'ANQ si aspetta un dataset con casi singoli, cioè non casi accorpati. Un dialogoo tra voi e l'ANQ in merito all'utilizzo del dataset SpiGes è in corso?
@@ -70,3 +71,5 @@ La formulazione è in realtà un po' contraddittoria. Si è ipotizzato che non c
 - I casi flex e tutti gli altri modelli assicurativi che stanno diventando sempre più popolari non sono davvero facili da mappare. Si tratta di una sfida per la classe assicurativa, ma non drammatica per le statistiche. In caso di dubbio, questi casi dovrebbero essere indicati come semi-privati.
 - La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
+{{<numberedList>}}
 1. Nel dataset SpiGes sono previsti casi a parentesi (= casi accorpati)? Nel campo della psichiatria, l'ANQ si aspetta un dataset con casi singoli, cioè non casi accorpati. Un dialogoo tra voi e l'ANQ in merito all'utilizzo del dataset SpiGes è in corso?
 {{<collapsibleBlock groupId="admninistratives">}}
 Il consolidamento dei casi viene gestito in SpiGes secondo le linee guida di SwissDRG AG. Siamo in dialogo con l'ANQ per quanto riguarda la gestione dei casi non accorpati.
@@ -83,5 +84,5 @@ La formulazione è in realtà un po' contraddittoria. Si è ipotizzato che non c
 - La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna.
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/1_administratives.md
+++ b/content/it/FAQ/Falldaten/1_administratives.md
@@ -11,47 +11,60 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="admninistratives">}}
 
 {{<numberedList>}}
-1. Nel dataset SpiGes sono previsti casi a parentesi (= casi accorpati)? Nel campo della psichiatria, l'ANQ si aspetta un dataset con casi singoli, cioè non casi accorpati. Un dialogoo tra voi e l'ANQ in merito all'utilizzo del dataset SpiGes è in corso?
+{{<listItem>}}
+Nel dataset SpiGes sono previsti casi a parentesi (= casi accorpati)? Nel campo della psichiatria, l'ANQ si aspetta un dataset con casi singoli, cioè non casi accorpati. Un dialogoo tra voi e l'ANQ in merito all'utilizzo del dataset SpiGes è in corso?
 {{<collapsibleBlock groupId="admninistratives">}}
 Il consolidamento dei casi viene gestito in SpiGes secondo le linee guida di SwissDRG AG. Siamo in dialogo con l'ANQ per quanto riguarda la gestione dei casi non accorpati.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. case_id_ch: Chi genera questo numero di caso e viene memorizzato automaticamente in Opale (sistema IRP)? Finora siamo riusciti a generare automaticamente in Opale l'identificazione del caso in entrambi i file (dati UST e file dei costi dei casi).
+{{<listItem>}}
+case_id_ch: Chi genera questo numero di caso e viene memorizzato automaticamente in Opale (sistema IRP)? Finora siamo riusciti a generare automaticamente in Opale l'identificazione del caso in entrambi i file (dati UST e file dei costi dei casi).
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - Il numero di casi unici a livello svizzero è generato dalla piattaforma SpiGes. Quando i dati vengono esportati dalla piattaforma, questo case_id_ch è disponibile per gli utenti dei dati.
 - L'identificatore del caso, la variabile fall_id, è generato dagli ospedali. Il software ospedaliero (ad es. Opale) dovrebbe continuare ad avere questa funzione.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Ci sono variabili (ad esempio la ventilazione) in cui il riferimento temporale è "intero caso" o "anno di indagine". Nella maggior parte degli ospedali, tuttavia, questa voce non viene registrata sull'asse temporale, ma solo una volta sul caso. Anche nel precedente dataset MS, tali voci erano sempre fornite solo per i casi A. Come pensate di fornire i casi B/C per queste variabili?
+{{<listItem>}}
+Ci sono variabili (ad esempio la ventilazione) in cui il riferimento temporale è "intero caso" o "anno di indagine". Nella maggior parte degli ospedali, tuttavia, questa voce non viene registrata sull'asse temporale, ma solo una volta sul caso. Anche nel precedente dataset MS, tali voci erano sempre fornite solo per i casi A. Come pensate di fornire i casi B/C per queste variabili?
 {{<collapsibleBlock groupId="admninistratives">}}
 In effetti, le definizioni di questo aspetto potrebbero non essere ancora completamente dettagliate per tutte le variabili. Ad oggi, non è stato stabilito se queste variabili debbano essere fornite per i casi B e C. 
 In linea di principio, dovrebbe essere possibile fornire le informazioni, solo allora sarà possibile calcolare i tassi di utilizzo con i dati. Tuttavia, è probabile che molti ospedali si trovino nella vostra stessa situazione e non dispongano dei dati per i casi B e C. In questo caso, le variabili per i casi B e C non sono disponibili quindi, le variabili relative ai casi B e C possono essere lasciate in bianco.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Qual è la definizione di «trasferimento interno»?
+{{<listItem>}}
+Qual è la definizione di «trasferimento interno»?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - È il passaggio da un reparto (acuto, psichiatria, riabilitazione) a un altro dello stesso ospedale (burnr_gesv)
 - Oppure si riferisce ai cosiddetti «pazienti in attesa»
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. È possibile ottenere una definizione per il valore «7 = Rimpatrio»?
+{{<listItem>}}
+È possibile ottenere una definizione per il valore «7 = Rimpatrio»?
 {{<collapsibleBlock groupId="admninistratives">}}
 Rimpatrio di un paziente con residenza principale svizzera dall'estero alla Svizzera, senza particolari requisiti per i mezzi di trasporto o la scorta 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Qual è la definizione per «trasferimento»? (ad es. i codici «5 = Trasferimento entro 24 ore» e «6 = Paziente ritrasferito» della variabile Modalità di ammissione)
+{{<listItem>}}
+Qual è la definizione per «trasferimento»? (ad es. i codici «5 = Trasferimento entro 24 ore» e «6 = Paziente ritrasferito» della variabile Modalità di ammissione)
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - La variabile Modalità di ammissione esisteva già nella MS e non ha subito modifiche nella piattaforma SpiGes. La differenza tra un trasferimento e un trasferimento interno, è che il primo non avviene all’interno dello stesso ospedale (BURGESV), ma tra ospedali diversi (due BURGESV diversi). La definizione si basa sui principi di SwissDRG AG, che potete trovare qui:  <a href="https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf"> https://www.swissdrg.org/application/files/8616/7051/1879/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7_i.pdf </a>
 - La seguente specifica è stata comunicata da SwissDRG AG per il tipo di ricovero "6=Retransfer": Per un ricovero ininterrotto in un altro ospedale per più di 18 giorni e ritorno all'ospedale di origine. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Come vengono codificati i casi trasferiti dalla riabilitazione (tariffa ST-REHA) alla lungodegenza (tariffa «tasse per le cure») nella stessa struttura? Le variabili 1.2.V02 e 1.5.V03 non consentono di specificare «Lungodegenza, stesso stabilimento».
+{{<listItem>}}
+Come vengono codificati i casi trasferiti dalla riabilitazione (tariffa ST-REHA) alla lungodegenza (tariffa «tasse per le cure») nella stessa struttura? Le variabili 1.2.V02 e 1.5.V03 non consentono di specificare «Lungodegenza, stesso stabilimento».
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 Questo era già così per la MS; il caso passa dalla riabilitazione alla SOMED (stesso stabilimento); il codice 2 contiene entrambe le opzioni (stesso stabilimento o altro stabilimento). Il caso deve essere codificato come segue:             
@@ -59,30 +72,38 @@ austritt_aufenthalt: 2 = casa di cura
 eintritt_aufenthalt: 84 = Reparto/Clinica di riabilitazione, stesso stabilimento
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ### Variabile «Wohnland»: 
 
-8. Nella descrizione delle variabili è menzionata una distinta ripartizione dei Paesi extraeuropei in regioni. Questo elenco esiste già o sarà pubblicato in futuro?
+{{<listItem>}}
+Nella descrizione delle variabili è menzionata una distinta ripartizione dei Paesi extraeuropei in regioni. Questo elenco esiste già o sarà pubblicato in futuro?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - La procedura e l'elenco sono gli stessi della statistica MS. Ecco il link per consultare l’elenco:  <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/cataloghi-banche-dati.assetdetail.10687501.html </a>
 - È possibile inserire le regioni per i Paesi non europei, ma è anche possibile specificare i codici dei Paesi. Questo è già il caso per la statistica MS e non è cambiato. Il formato è alfanumerico e può quindi contenere sia numeri che lettere.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
 ###	35.	Variabile "classe assicurativa": 
 
-9. La descrizione della variabile afferma che deve essere specificata per tutti, tranne per coloro che pagano direttamente la prestazione. Nel file xsd, tuttavia, il campo è "required". Che cosa dobbiamo fornire per coloro che pagano direttamente la prestazione?
+{{<listItem>}}
+La descrizione della variabile afferma che deve essere specificata per tutti, tranne per coloro che pagano direttamente la prestazione. Nel file xsd, tuttavia, il campo è "required". Che cosa dobbiamo fornire per coloro che pagano direttamente la prestazione?
 {{<collapsibleBlock groupId="admninistratives">}}
 La formulazione è in realtà un po' contraddittoria. Si è ipotizzato che non ci siano mancanze. Poi, naturalmente, vale anche per coloro che pagano direttamente la prestazione, che sono codificati con 9=sconosciuto.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-10.	Secondo la nostra amministrazione dei pazienti, è difficile ottenere le informazioni per i casi con "assicurazione Flex" e inserire "8 = altro".  Ci saranno problemi in seguito nelle analisi o quali effetti ci saranno sulle statistiche se non (o non possiamo) inserire "8=altro"?
+{{<listItem>}}
+Secondo la nostra amministrazione dei pazienti, è difficile ottenere le informazioni per i casi con "assicurazione Flex" e inserire "8 = altro".  Ci saranno problemi in seguito nelle analisi o quali effetti ci saranno sulle statistiche se non (o non possiamo) inserire "8=altro"?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
 - I casi flex e tutti gli altri modelli assicurativi che stanno diventando sempre più popolari non sono davvero facili da mappare. Si tratta di una sfida per la classe assicurativa, ma non drammatica per le statistiche. In caso di dubbio, questi casi dovrebbero essere indicati come semi-privati.
 - La variabile "liegeklasse", invece, è centrale per la mappatura dell'ITAR_K. Inoltre, non esiste la categoria "altro" e i casi con "sconosciuto" saranno esaminati. A seconda del valore di questa variabile, i casi in ITAR_K sono assegnati a una diversa colonna.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/it/FAQ/Falldaten/3_psychiatrie.md
@@ -11,11 +11,14 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 {{<numberedList>}}
-1. Variabile psy_zivilstand: cosa si intende con il codice «5 = non coniugato/a» e come si distingue da celibe/nubile ecc.?
+{{<listItem>}}
+Variabile psy_zivilstand: cosa si intende con il codice «5 = non coniugato/a» e come si distingue da celibe/nubile ecc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
 Per la variabile «stato civile» l’UST utilizza un elenco di codici standardizzati. Lo stato civile «non coniugato/a» è valido in caso di dichiarazione di nullità dell’ultimo matrimonio o in caso di dichiarazione di scomparsa dell’ultimo/a coniuge. Cfr. link: [https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html](https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/it/FAQ/Falldaten/3_psychiatrie.md
@@ -10,11 +10,12 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
+{{<numberedList>}}
 1. Variabile psy_zivilstand: cosa si intende con il codice «5 = non coniugato/a» e come si distingue da celibe/nubile ecc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 {{<markdown>}}
 Per la variabile «stato civile» l’UST utilizza un elenco di codici standardizzati. Lo stato civile «non coniugato/a» è valido in caso di dichiarazione di nullità dell’ultimo matrimonio o in caso di dichiarazione di scomparsa dell’ultimo/a coniuge. Cfr. link: [https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html](https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/it/FAQ/Falldaten/3_psychiatrie.md
@@ -7,9 +7,12 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variabile psy_zivilstand: cosa si intende con il codice «5 = non coniugato/a» e come si distingue da celibe/nubile ecc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
 Per la variabile «stato civile» l’UST utilizza un elenco di codici standardizzati. Lo stato civile «non coniugato/a» è valido in caso di dichiarazione di nullità dell’ultimo matrimonio o in caso di dichiarazione di scomparsa dell’ultimo/a coniuge. Cfr. link: <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html </a> 
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/3_psychiatrie.md
+++ b/content/it/FAQ/Falldaten/3_psychiatrie.md
@@ -12,7 +12,9 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="psychiatrie">}}
 
 1. Variabile psy_zivilstand: cosa si intende con il codice «5 = non coniugato/a» e come si distingue da celibe/nubile ecc.?
 {{<collapsibleBlock groupId="psychiatrie">}}
-Per la variabile «stato civile» l’UST utilizza un elenco di codici standardizzati. Lo stato civile «non coniugato/a» è valido in caso di dichiarazione di nullità dell’ultimo matrimonio o in caso di dichiarazione di scomparsa dell’ultimo/a coniuge. Cfr. link: <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html </a> 
+{{<markdown>}}
+Per la variabile «stato civile» l’UST utilizza un elenco di codici standardizzati. Lo stato civile «non coniugato/a» è valido in caso di dichiarazione di nullità dell’ultimo matrimonio o in caso di dichiarazione di scomparsa dell’ultimo/a coniuge. Cfr. link: [https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html](https://www.bfs.admin.ch/bfs/it/home/statistiche/popolazione/effettivo-evoluzione/stato-civile.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -12,11 +12,14 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1. Variabile POA: potrebbe dirci a quale scopo viene utilizzata la variabile diagnose_poa?  
 {{<collapsibleBlock groupId="diagnose">}}
-L’indicazione «POA» (present on admission) può essere utilizzata, tra l’altro, per migliorare la qualità e per la sicurezza dei pazienti. Si veda, ad esempio, la comunicazione del Cantone di Zurigo in merito (in tedesco). <a href="https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf"> Present on admission – Informationen zur Erfassung (zh.ch) </a>
+{{<markdown>}}
+L’indicazione «POA» (present on admission) può essere utilizzata, tra l’altro, per migliorare la qualità e per la sicurezza dei pazienti. Si veda, ad esempio, la comunicazione del Cantone di Zurigo in merito (in tedesco). [Present on admission – Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Variabile «diagnose_zusatz»: quali informazioni devono essere inserite qui per i codici con asterisco e i codici con punto esclamativo?
 {{<collapsibleBlock groupId="diagnose">}}
+{{<markdown>}}
 -	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. 
 -	I codici con asterisco non sono contrassegnati come tali; sono assegnati secondo l’ICD-10-GM. 
 
@@ -25,7 +28,8 @@ DP E10.73† Diabete mellito, tipo 1, con complicanze multipl, definito come sco
 DS I79.2* Angiopatia periferica in malattie classificate altrove      
 DS H36.0* Retinopatia diabetica       
 DS N08.3* Disturbi glomerulari in diabete mellito       
-…va indicato in **SpiGe** come segue :      
+…va indicato in **SpiGe** come segue :   
+{{</markdown>}}   
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -54,6 +58,7 @@ DS N08.3* Disturbi glomerulari in diabete mellito
   </tr>
 </table>
 
+{{<markdown>}}
 **Esempio** nel Manuale di codifica (pag. 40)      
 DP S37.03 Rottura completa del parenchima renale      
 L 2       
@@ -61,7 +66,8 @@ DS V99! Incidente da trasporto non specificato
 DS S36.03 Lacerazione della milza con interessamento del parenchima       
 DS S36.49 Traumatismo di altre e multiple parti dell’intestino tenue      
 DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi) in collegamento con traumatismo intraaddominale       
-…va indicato in **SpiGe** come segue:      
+…va indicato in **SpiGe** come segue:     
+{{</markdown>}} 
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -20,13 +20,12 @@ L’indicazione «POA» (present on admission) può essere utilizzata, tra l’a
 -	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. 
 -	I codici con asterisco non sono contrassegnati come tali; sono assegnati secondo l’ICD-10-GM. 
 
-<p>
-<b> Esempio 4 </b> nel Manuale di codifica (pag. 38) <br />
-DP E10.73† Diabete mellito, tipo 1, con complicanze multipl, definito come scompensato <br />
-DS I79.2* Angiopatia periferica in malattie classificate altrove <br />
-DS H36.0* Retinopatia diabetica <br />
-DS N08.3* Disturbi glomerulari in diabete mellito <br />
-…va indicato in <b>SpiGes</b> come segue : <br />
+**Esempio 4** nel Manuale di codifica (pag. 38)       
+DP E10.73† Diabete mellito, tipo 1, con complicanze multipl, definito come scompensato      
+DS I79.2* Angiopatia periferica in malattie classificate altrove      
+DS H36.0* Retinopatia diabetica       
+DS N08.3* Disturbi glomerulari in diabete mellito       
+…va indicato in **SpiGe** come segue :      
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -54,17 +53,16 @@ DS N08.3* Disturbi glomerulari in diabete mellito <br />
     <td> E10.73 </td>
   </tr>
 </table>
-</p>
 
-<p>
-<b>Esempio 4</b> nel Manuale di codifica (pag. 40) <br />
-DP S37.03 Rottura completa del parenchima renale <br />
-L 2  <br />
-DS V99! Incidente da trasporto non specificato <br />
-DS S36.03 Lacerazione della milza con interessamento del parenchima <br />
-DS S36.49 Traumatismo di altre e multiple parti dell’intestino tenue <br />
-DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi) in collegamento con traumatismo intraaddominale <br />
-…va indicato in <b> SpiGes</b> come segue: <br />
+
+**Esempio** nel Manuale di codifica (pag. 40)      
+DP S37.03 Rottura completa del parenchima renale      
+L 2       
+DS V99! Incidente da trasporto non specificato      
+DS S36.03 Lacerazione della milza con interessamento del parenchima       
+DS S36.49 Traumatismo di altre e multiple parti dell’intestino tenue      
+DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi) in collegamento con traumatismo intraaddominale       
+…va indicato in **SpiGe** come segue:      
 <table class="w-100">
   <tr>
     <th style="width:35%"> diagnose_kode </div></th>
@@ -107,5 +105,4 @@ DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi
     <td> S37.03 </td>
   </tr>
 </table>
-</p>
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 1. Variabile POA: potrebbe dirci a quale scopo viene utilizzata la variabile diagnose_poa?  
@@ -104,3 +105,5 @@ DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi
   </tr>
 </table>
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -16,10 +16,10 @@ L’indicazione «POA» (present on admission) può essere utilizzata, tra l’a
 
 2. Variabile «diagnose_zusatz»: quali informazioni devono essere inserite qui per i codici con asterisco e i codici con punto esclamativo?
 {{<collapsibleBlock groupId="diagnose">}}
-<ul>
-<li>	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. </li>
-<li>	I codici con asterisco non sono contrassegnati come tali; sono assegnati secondo l’ICD-10-GM. </li>
-</ul>
+
+-	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. 
+-	I codici con asterisco non sono contrassegnati come tali; sono assegnati secondo l’ICD-10-GM. 
+
 <p>
 <b> Esempio 4 </b> nel Manuale di codifica (pag. 38) <br />
 DP E10.73† Diabete mellito, tipo 1, con complicanze multipl, definito come scompensato <br />

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="diagnose">}}
 
+{{<numberedList>}}
 1. Variabile POA: potrebbe dirci a quale scopo viene utilizzata la variabile diagnose_poa?  
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
@@ -111,5 +112,5 @@ DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi
   </tr>
 </table>
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -11,14 +11,17 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="diagnose">}}
 
 {{<numberedList>}}
-1. Variabile POA: potrebbe dirci a quale scopo viene utilizzata la variabile diagnose_poa?  
+{{<listItem>}}
+Variabile POA: potrebbe dirci a quale scopo viene utilizzata la variabile diagnose_poa?  
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 L’indicazione «POA» (present on admission) può essere utilizzata, tra l’altro, per migliorare la qualità e per la sicurezza dei pazienti. Si veda, ad esempio, la comunicazione del Cantone di Zurigo in merito (in tedesco). [Present on admission – Informationen zur Erfassung (zh.ch)](https://www.zh.ch/content/dam/zhweb/bilder-dokumente/themen/gesundheit/gesundheitsversorgung/spitaeler_kliniken/daten_und_statistik_der_listenspitaeler/datenerhebung/poa_informationen.pdf).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Variabile «diagnose_zusatz»: quali informazioni devono essere inserite qui per i codici con asterisco e i codici con punto esclamativo?
+{{<listItem>}}
+Variabile «diagnose_zusatz»: quali informazioni devono essere inserite qui per i codici con asterisco e i codici con punto esclamativo?
 {{<collapsibleBlock groupId="diagnose">}}
 {{<markdown>}}
 -	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. 
@@ -112,5 +115,7 @@ DS S31.83! Ferita aperta (qualsiasi parte dell’addome, dei lombi e della pelvi
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/4_diagnose.md
+++ b/content/it/FAQ/Falldaten/4_diagnose.md
@@ -16,7 +16,6 @@ L’indicazione «POA» (present on admission) può essere utilizzata, tra l’a
 
 2. Variabile «diagnose_zusatz»: quali informazioni devono essere inserite qui per i codici con asterisco e i codici con punto esclamativo?
 {{<collapsibleBlock groupId="diagnose">}}
-
 -	Per i codici con asterisco, qui va inserito il corrispondente codice con croce. Per i codici con punto esclamativo, il codice da specificare. 
 -	I codici con asterisco non sono contrassegnati come tali; sono assegnati secondo l’ICD-10-GM. 
 
@@ -53,7 +52,6 @@ DS N08.3* Disturbi glomerulari in diabete mellito
     <td> E10.73 </td>
   </tr>
 </table>
-
 
 **Esempio** nel Manuale di codifica (pag. 40)      
 DP S37.03 Rottura completa del parenchima renale      

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -12,25 +12,20 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
 
-- 	Conformemente alla descrizione delle variabili vale quanto segue: <br />
-Numero univoco progressivo del trattamento. <br />
-1 = Trattamento 1 <br />
-2 = Trattamento 2 <br />
-3 = Trattamento 3 <br />
-(…) ecc. -> illimitato <br />
+- Conformemente alla descrizione delle variabili vale quanto segue:       
+Numero univoco progressivo del trattamento.         
+1 = Trattamento 1       
+2 = Trattamento 2       
+3 = Trattamento 3       
+(…) ecc. -> illimitato      
 Per la sequenza dei trattamenti si raccomanda di attenersi ai criteri seguenti:
-<ol>
-- Procedure per il trattamento della diagnosi principale 
-- Procedure per il trattamento delle diagnosi secondarie 
-- Procedure per la determinazione della diagnosi principale 
-- Procedure per la determinazione delle diagnosi secondarie 
-- Altre procedure 
-</ol>
+1. Procedure per il trattamento della diagnosi principale 
+2. Procedure per il trattamento delle diagnosi secondarie 
+3. Procedure per la determinazione della diagnosi principale 
+4. Procedure per la determinazione delle diagnosi secondarie 
+5. Altre procedure 
 
--
-Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
-
-
+- Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
 {{</collapsibleBlock>}}
 
 2. Siamo un po’ preoccupati che questi dati non vengano registrati in modo completo, soprattutto nei primi giorni, e che ciò renda necessari ulteriori aggiustamenti supplementari. Vorremmo quindi definire il campo come obbligatorio per i codici CHOP interessati. Esiste una classificazione per il catalogo CHOP per quanto riguarda i codici considerati operativi o interventistici?
@@ -41,6 +36,6 @@ L’UST è consapevole che con l’introduzione del nuovo modo di inserire i dat
 3. Operatori: Qui c'è un problema di interpretazione delle specifiche nel file XML. La descrizione della variabile afferma che si possono contare al massimo due operatori per ogni operazione. Nella panoramica, tuttavia, l'attributo non indica se questo può essere esportato più volte.
 {{<insertImage image="Image1.jpg" class="edge max-w-90">}}
 {{<collapsibleBlock groupId="behandlungen">}}
-	Quanti chirurghi possono essere conteggiati per un'operazione è una questione concettuale e può variare da cantone a cantone (di solito 2, ma è una linea guida!). Tecnicamente, possono essere conteggiati più chirurghi.
+Quanti chirurghi possono essere conteggiati per un'operazione è una questione concettuale e può variare da cantone a cantone (di solito 2, ma è una linea guida!). Tecnicamente, possono essere conteggiati più chirurghi.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
+{{<numberedList>}}
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
@@ -41,5 +42,5 @@ L’UST è consapevole che con l’introduzione del nuovo modo di inserire i dat
 Quanti chirurghi possono essere conteggiati per un'operazione è una questione concettuale e può variare da cantone a cantone (di solito 2, ma è una linea guida!). Tecnicamente, possono essere conteggiati più chirurghi.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
@@ -38,3 +39,5 @@ L’UST è consapevole che con l’introduzione del nuovo modo di inserire i dat
 Quanti chirurghi possono essere conteggiati per un'operazione è una questione concettuale e può variare da cantone a cantone (di solito 2, ma è una linea guida!). Tecnicamente, possono essere conteggiati più chirurghi.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -15,18 +15,20 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
-- Conformemente alla descrizione delle variabili vale quanto segue:       
-Numero univoco progressivo del trattamento.         
-1 = Trattamento 1       
-2 = Trattamento 2       
-3 = Trattamento 3       
-(…) ecc. -> illimitato      
+
+- Conformemente alla descrizione delle variabili vale quanto segue:
+Numero univoco progressivo del trattamento.
+1 = Trattamento 1
+2 = Trattamento 2
+3 = Trattamento 3
+(…) ecc. -> illimitato
 Per la sequenza dei trattamenti si raccomanda di attenersi ai criteri seguenti:
-1. Procedure per il trattamento della diagnosi principale 
-2. Procedure per il trattamento delle diagnosi secondarie 
-3. Procedure per la determinazione della diagnosi principale 
-4. Procedure per la determinazione delle diagnosi secondarie 
-5. Altre procedure 
+
+1. Procedure per il trattamento della diagnosi principale
+2. Procedure per il trattamento delle diagnosi secondarie
+3. Procedure per la determinazione della diagnosi principale
+4. Procedure per la determinazione delle diagnosi secondarie
+5. Altre procedure
 
 - Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
 {{</markdown>}}

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -12,6 +12,7 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
+{{<markdown>}}
 - Conformemente alla descrizione delle variabili vale quanto segue:       
 Numero univoco progressivo del trattamento.         
 1 = Trattamento 1       
@@ -26,6 +27,7 @@ Per la sequenza dei trattamenti si raccomanda di attenersi ai criteri seguenti:
 5. Altre procedure 
 
 - Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Siamo un po’ preoccupati che questi dati non vengano registrati in modo completo, soprattutto nei primi giorni, e che ciò renda necessari ulteriori aggiustamenti supplementari. Vorremmo quindi definire il campo come obbligatorio per i codici CHOP interessati. Esiste una classificazione per il catalogo CHOP per quanto riguarda i codici considerati operativi o interventistici?

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -11,8 +11,8 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
-<ul>
-<li> 	Conformemente alla descrizione delle variabili vale quanto segue: <br />
+
+- 	Conformemente alla descrizione delle variabili vale quanto segue: <br />
 Numero univoco progressivo del trattamento. <br />
 1 = Trattamento 1 <br />
 2 = Trattamento 2 <br />
@@ -20,17 +20,17 @@ Numero univoco progressivo del trattamento. <br />
 (…) ecc. -> illimitato <br />
 Per la sequenza dei trattamenti si raccomanda di attenersi ai criteri seguenti:
 <ol>
-<li> Procedure per il trattamento della diagnosi principale </li>
-<li> Procedure per il trattamento delle diagnosi secondarie </li>
-<li> Procedure per la determinazione della diagnosi principale </li>
-<li> Procedure per la determinazione delle diagnosi secondarie </li>
-<li> Altre procedure </li>
+- Procedure per il trattamento della diagnosi principale 
+- Procedure per il trattamento delle diagnosi secondarie 
+- Procedure per la determinazione della diagnosi principale 
+- Procedure per la determinazione delle diagnosi secondarie 
+- Altre procedure 
 </ol>
-</li>
-<li>
+
+-
 Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
-</li>
-</ul>
+
+
 {{</collapsibleBlock>}}
 
 2. Siamo un po’ preoccupati che questi dati non vengano registrati in modo completo, soprattutto nei primi giorni, e che ciò renda necessari ulteriori aggiustamenti supplementari. Vorremmo quindi definire il campo come obbligatorio per i codici CHOP interessati. Esiste una classificazione per il catalogo CHOP per quanto riguarda i codici considerati operativi o interventistici?

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,6 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
-
 - Conformemente alla descrizione delle variabili vale quanto segue:       
 Numero univoco progressivo del trattamento.         
 1 = Trattamento 1       

--- a/content/it/FAQ/Falldaten/5_behandlungen.md
+++ b/content/it/FAQ/Falldaten/5_behandlungen.md
@@ -11,7 +11,8 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="behandlungen">}}
 
 {{<numberedList>}}
-1. Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
+{{<listItem>}}
+Variabile «behandlung_id»: ci sono raccomandazioni per la sequenza da applicare in psichiatria? In particolare, gli item HoNOS, forniti nel quadro della CHOP, non sono specifici alla diagnosi o al trattamento.
 {{<collapsibleBlock groupId="behandlungen">}}
 {{<markdown>}}
 - Conformemente alla descrizione delle variabili vale quanto segue:       
@@ -30,17 +31,23 @@ Per la sequenza dei trattamenti si raccomanda di attenersi ai criteri seguenti:
 - Raccomandiamo una numerazione cronologica per gli item HoNOS (misurazioni HoNOS temporalmente remote = ID bassi, misurazioni HoNOS recenti = ID alti).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Siamo un po’ preoccupati che questi dati non vengano registrati in modo completo, soprattutto nei primi giorni, e che ciò renda necessari ulteriori aggiustamenti supplementari. Vorremmo quindi definire il campo come obbligatorio per i codici CHOP interessati. Esiste una classificazione per il catalogo CHOP per quanto riguarda i codici considerati operativi o interventistici?
+{{<listItem>}}
+Siamo un po’ preoccupati che questi dati non vengano registrati in modo completo, soprattutto nei primi giorni, e che ciò renda necessari ulteriori aggiustamenti supplementari. Vorremmo quindi definire il campo come obbligatorio per i codici CHOP interessati. Esiste una classificazione per il catalogo CHOP per quanto riguarda i codici considerati operativi o interventistici?
 {{<collapsibleBlock groupId="behandlungen">}}
 L’UST è consapevole che con l’introduzione del nuovo modo di inserire i dati, all’inizio questi saranno incompleti. Dopo la consueta fase di consolidamento, si capirà quali precisazioni saranno necessarie. Non è possibile determinare chiaramente per ogni codice CHOP se richiede o meno l’indicazione dell’ora. Ci sono altre caratteristiche che sono decisive in questo caso: se il trattamento è legato all’utilizzo di una sala operatoria o di un laboratorio di cateterismo cardiaco.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Operatori: Qui c'è un problema di interpretazione delle specifiche nel file XML. La descrizione della variabile afferma che si possono contare al massimo due operatori per ogni operazione. Nella panoramica, tuttavia, l'attributo non indica se questo può essere esportato più volte.
+{{<listItem>}}
+Operatori: Qui c'è un problema di interpretazione delle specifiche nel file XML. La descrizione della variabile afferma che si possono contare al massimo due operatori per ogni operazione. Nella panoramica, tuttavia, l'attributo non indica se questo può essere esportato più volte.
 {{<insertImage image="Image1.jpg" class="edge max-w-90">}}
 {{<collapsibleBlock groupId="behandlungen">}}
 Quanti chirurghi possono essere conteggiati per un'operazione è una questione concettuale e può variare da cantone a cantone (di solito 2, ma è una linea guida!). Tecnicamente, possono essere conteggiati più chirurghi.
 {{<insertImage image="Image2.png" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/6_medikamente.md
+++ b/content/it/FAQ/Falldaten/6_medikamente.md
@@ -11,9 +11,12 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="medikamente">}}
 {{<numberedList>}}
 
-1. «medi_id»: i numeri delle prestazioni presso i nostri clienti possono essere alfanumerici, mentre la variabile è fornita solo numericamente. Sarebbe possibile anche in questo caso esportare il Pharmacode o il GTIN?
+{{<listItem>}}
+«medi_id»: i numeri delle prestazioni presso i nostri clienti possono essere alfanumerici, mentre la variabile è fornita solo numericamente. Sarebbe possibile anche in questo caso esportare il Pharmacode o il GTIN?
 {{<collapsibleBlock groupId="medikamente">}}
 Questa variabile è stata aggiunta per motivi puramente tecnici (struttura XML) e rappresenta un numero di riga univoco della tabella tematica «Medicamenti». Purché la variabile venga compilata in modo chiaro e completo, in teoria si possono inserire anche Pharmacode o GTIN. Tuttavia, l’UST dubita che queste condizioni possano essere soddisfatte per tutti i medicinali. Semplicemente per alcuni, queste informazioni non sono ancora disponibili.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/6_medikamente.md
+++ b/content/it/FAQ/Falldaten/6_medikamente.md
@@ -9,10 +9,11 @@ keywords: []
 
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="medikamente">}}
+{{<numberedList>}}
 
 1. «medi_id»: i numeri delle prestazioni presso i nostri clienti possono essere alfanumerici, mentre la variabile è fornita solo numericamente. Sarebbe possibile anche in questo caso esportare il Pharmacode o il GTIN?
 {{<collapsibleBlock groupId="medikamente">}}
 Questa variabile è stata aggiunta per motivi puramente tecnici (struttura XML) e rappresenta un numero di riga univoco della tabella tematica «Medicamenti». Purché la variabile venga compilata in modo chiaro e completo, in teoria si possono inserire anche Pharmacode o GTIN. Tuttavia, l’UST dubita che queste condizioni possano essere soddisfatte per tutti i medicinali. Semplicemente per alcuni, queste informazioni non sono ancora disponibili.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/6_medikamente.md
+++ b/content/it/FAQ/Falldaten/6_medikamente.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="medikamente">}}
 
 1. «medi_id»: i numeri delle prestazioni presso i nostri clienti possono essere alfanumerici, mentre la variabile è fornita solo numericamente. Sarebbe possibile anche in questo caso esportare il Pharmacode o il GTIN?
@@ -14,3 +15,4 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="medikamente">}}
 Questa variabile è stata aggiunta per motivi puramente tecnici (struttura XML) e rappresenta un numero di riga univoco della tabella tematica «Medicamenti». Purché la variabile venga compilata in modo chiaro e completo, in teoria si possono inserire anche Pharmacode o GTIN. Tuttavia, l’UST dubita che queste condizioni possano essere soddisfatte per tutti i medicinali. Semplicemente per alcuni, queste informazioni non sono ancora disponibili.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
 1. Viene esportata una riga per ogni fattura emessa e ogni remunerazione supplementare?
@@ -20,3 +21,4 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 -	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. 
 -	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -17,8 +17,10 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 
 2. Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
 {{<collapsibleBlock groupId="rechnungen">}}
+{{<markdown>}}
 -	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. 
 -	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. 
 -	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
+{{<numberedList>}}
 1. Viene esportata una riga per ogni fattura emessa e ogni remunerazione supplementare?
 {{<collapsibleBlock groupId="rechnungen">}}
 La rilevazione deve essere effettuata con la stessa granularità delle righe delle fatture inviate. Se, per esempio, per un caso con assicurazione di base sono conteggiati e fatturati all’assicurazione di base e al Cantone un forfait per caso e una remunerazione supplementare, devono essere registrate quattro righe (1. forfait Cantone, 2. remunerazione supplementare Cantone, 3. forfait assicuratore, 4. remunerazione supplementare assicuratore).
@@ -23,4 +24,5 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 -	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -11,12 +11,15 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="rechnungen">}}
 
 {{<numberedList>}}
-1. Viene esportata una riga per ogni fattura emessa e ogni remunerazione supplementare?
+{{<listItem>}}
+Viene esportata una riga per ogni fattura emessa e ogni remunerazione supplementare?
 {{<collapsibleBlock groupId="rechnungen">}}
 La rilevazione deve essere effettuata con la stessa granularità delle righe delle fatture inviate. Se, per esempio, per un caso con assicurazione di base sono conteggiati e fatturati all’assicurazione di base e al Cantone un forfait per caso e una remunerazione supplementare, devono essere registrate quattro righe (1. forfait Cantone, 2. remunerazione supplementare Cantone, 3. forfait assicuratore, 4. remunerazione supplementare assicuratore).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
+{{<listItem>}}
+Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
 {{<collapsibleBlock groupId="rechnungen">}}
 {{<markdown>}}
 -	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. 
@@ -24,5 +27,7 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 -	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,9 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 
 2. Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
 {{<collapsibleBlock groupId="rechnungen">}}
-<ul>
-<li>	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. </li>
-<li>	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. </li>
-<li>	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. </li>
-</ul>
+
+-	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. 
+-	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. 
+-	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
+
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -16,9 +16,7 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 
 2. Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
 {{<collapsibleBlock groupId="rechnungen">}}
-
 -	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. 
 -	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. 
 -	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
-
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/7_rechnungen.md
+++ b/content/it/FAQ/Falldaten/7_rechnungen.md
@@ -22,9 +22,10 @@ La rilevazione deve essere effettuata con la stessa granularità delle righe del
 Come vengono compilati i relativi campi per le fatture che non vengono fatturate attraverso SwissDRG, TARPSY o ST Reha?
 {{<collapsibleBlock groupId="rechnungen">}}
 {{<markdown>}}
--	Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario. 
--	Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità. 
--	I campi che non hanno senso per altre tariffe possono essere lasciati vuoti. 
+
+- Sostanzialmente analogamente al sito Forum Datenaustausch, la compilazione riguarda solo i trattamenti nel settore stazionario.
+- Occorre chiarezza per quanto riguarda la tariffa, l’importo e la quantità.
+- I campi che non hanno senso per altre tariffe possono essere lasciati vuoti.
 {{</markdown>}}
 {{</collapsibleBlock>}}
 {{</listItem>}}

--- a/content/it/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/it/FAQ/Falldaten/8_patientenbewegung.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 1. Anche l’ammissione e la dimissione contano come un episodio?
@@ -50,3 +51,5 @@ Sì, la data e le ore devono essere fornite per tutti gli episodi, sia all'inizi
 Sì, b n caso di trattamento ambulatoriale esterno, è possibile indicare il numero di BUR della sede di cura, se noto.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/it/FAQ/Falldaten/8_patientenbewegung.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
+{{<numberedList>}}
 1. Anche l’ammissione e la dimissione contano come un episodio?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 L’ammissione e la dimissione sono indicate come prima nel campo «data di ammissione» e «data di dimissione». Se il caso non è stato trasferito, non viene registrato alcun episodio. Se però si dovesse arrivare a un trasferimento (p. es. una dimissione intermedia) quale episodio 1 varrebbe il periodo dalla data di ammissione a quella della dimissione intermedia. L’episodio 2 inizia con la dimissione intermedia e termina con la riammissione. L’episodio 3 inizia con la riammissione e termina con il trasferimento successivo (p. es. le vacanze). Così facendo, per uno stesso caso si possono avere diversi episodi (v. illustrazione). L’ultimo episodio (9) si conclude con la data di dimissione. Gli episodi sono gli intervalli temporali prima e dopo eventi riguardanti un caso, quali: cambio di sede, dimissioni intermedie / riammissioni, trattamenti ambulatoriali esterni, congedi e uscite di prova.
@@ -51,5 +52,5 @@ Sì, la data e le ore devono essere fornite per tutti gli episodi, sia all'inizi
 Sì, b n caso di trattamento ambulatoriale esterno, è possibile indicare il numero di BUR della sede di cura, se noto.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/8_patientenbewegung.md
+++ b/content/it/FAQ/Falldaten/8_patientenbewegung.md
@@ -11,46 +11,63 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="patientenbewegung">}}
 
 {{<numberedList>}}
-1. Anche l’ammissione e la dimissione contano come un episodio?
+{{<listItem>}}
+Anche l’ammissione e la dimissione contano come un episodio?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 L’ammissione e la dimissione sono indicate come prima nel campo «data di ammissione» e «data di dimissione». Se il caso non è stato trasferito, non viene registrato alcun episodio. Se però si dovesse arrivare a un trasferimento (p. es. una dimissione intermedia) quale episodio 1 varrebbe il periodo dalla data di ammissione a quella della dimissione intermedia. L’episodio 2 inizia con la dimissione intermedia e termina con la riammissione. L’episodio 3 inizia con la riammissione e termina con il trasferimento successivo (p. es. le vacanze). Così facendo, per uno stesso caso si possono avere diversi episodi (v. illustrazione). L’ultimo episodio (9) si conclude con la data di dimissione. Gli episodi sono gli intervalli temporali prima e dopo eventi riguardanti un caso, quali: cambio di sede, dimissioni intermedie / riammissioni, trattamenti ambulatoriali esterni, congedi e uscite di prova.
 {{<insertImage image="Image3_it.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Un caso che cambia sede viene gestito in entrambe le sedi?
+{{<listItem>}}
+Un caso che cambia sede viene gestito in entrambe le sedi?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 No, ogni caso viene gestito solo nella sede principale, anche se viene trasferito da una sede all’altra all’interno di un ospedale (BURGESV). Se un paziente viene trasferito in un altro ospedale (BURGESV), è necessario aprire un nuovo caso
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Variabili "re-entry_stay" e "reason_re-entry": perché queste voci possono essere inserite solo per i casi A se tutte le voci degli episodi sono destinate ai casi ABC?
+{{<listItem>}}
+Variabili "re-entry_stay" e "reason_re-entry": perché queste voci possono essere inserite solo per i casi A se tutte le voci degli episodi sono destinate ai casi ABC?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Da chiarimenti con SwissDRG AG è emerso che le due variabili "re_admission_stay" e "reason_re_admission" possono essere specificate per i casi statistici ABC. La descrizione delle variabili 1.4 ne terrà conto.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Episodio_id: riteniamo che per la nostra clinica non sia necessario differenziare gli episodi per i casi di ricovero, in quanto non registriamo alcun cambiamento di sede all'interno dell'ospedale. Abbiamo capito bene?
+{{<listItem>}}
+Episodio_id: riteniamo che per la nostra clinica non sia necessario differenziare gli episodi per i casi di ricovero, in quanto non registriamo alcun cambiamento di sede all'interno dell'ospedale. Abbiamo capito bene?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Questa ipotesi si applica agli episodi dovuti a cambiamenti di sede. Tuttavia, devono essere registrati gli episodi dovuti a uscite/rientri intermedi, vacanze, test da sforzo o trattamenti ambulatoriali fuori sede.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Abbiamo capito bene, ad esempio che l'ingresso al trattamento ambulatoriale fuori casa (vedi figura sotto) è già un episodio? Quindi abbiamo sempre un episode_type="1" tra vacanze, test da sforzo e trattamento ambulatoriale?
+{{<listItem>}}
+Abbiamo capito bene, ad esempio che l'ingresso al trattamento ambulatoriale fuori casa (vedi figura sotto) è già un episodio? Quindi abbiamo sempre un episode_type="1" tra vacanze, test da sforzo e trattamento ambulatoriale?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Corretto
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Nell'esempio (vedi figura sotto), non ci sono cambi di sede all'interno dello stesso ospedale. Abbiamo capito bene che l'ubicazione del numero BUR dell'ospedale deve essere sempre specificata per il tipo_di_episodio="1"?
+{{<listItem>}}
+Nell'esempio (vedi figura sotto), non ci sono cambi di sede all'interno dello stesso ospedale. Abbiamo capito bene che l'ubicazione del numero BUR dell'ospedale deve essere sempre specificata per il tipo_di_episodio="1"?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Corretto
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-7. Per quanto ne sappiamo, l'orario di rientro dal trattamento ambulatoriale non è documentato. Tuttavia, potrebbe essere registrato nei sistemi informativi degli ospedali. Queste informazioni sono obbligatorie?
+{{<listItem>}}
+Per quanto ne sappiamo, l'orario di rientro dal trattamento ambulatoriale non è documentato. Tuttavia, potrebbe essere registrato nei sistemi informativi degli ospedali. Queste informazioni sono obbligatorie?
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Sì, la data e le ore devono essere fornite per tutti gli episodi, sia all'inizio che alla fine. Se la fine di un trattamento ambulatoriale extraospedaliero non è registrata, si consiglia di aggiungere questa informazione. Se ciò non è possibile (in tempi brevi), si consiglia di utilizzare una durata standard per il trattamento ambulatoriale fuori casa.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-8. Il BURNR dell'ospedale fuori città è facoltativo, giusto? 
+{{<listItem>}}
+Il BURNR dell'ospedale fuori città è facoltativo, giusto? 
 {{<collapsibleBlock groupId="patientenbewegung">}}
 Sì, b n caso di trattamento ambulatoriale esterno, è possibile indicare il numero di BUR della sede di cura, se noto.
 {{<insertImage image="Image4.jpg" class="edge max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -22,8 +22,6 @@ Se l'organizzazione compila il SOMED, questi costi devono essere registrati in S
 3. Supplementi per i costi di utilizzo degli impianti (ANK) per i costi diretti: secondo REKOLE® , i supplementi ANK possono essere registrati 
 per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tuttavia, non esistono variabili ANK separate in SpiGes e nei dataset dei costi SwissDRG, a differenza delle spese generali, sulle quali è possibile registrare i costi di utilizzo degli impianti secondo REKOLE. In ITAR_K, i conti 400 e 401 devono essere specificati senza supplementi ANK. Cosa si deve fare con questi supplementi ANK sui conti 400 e 401?
 {{<collapsibleBlock groupId="kostentraeger">}}
-
 - Le maggiorazioni dell'ANK non devono essere registrate nei conti 400 e 401. Tuttavia, devono essere inclusi nelle variabili totali dell'ANK (ktr_44_vkl / ktr_44_rekole). 
 - Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
-
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 1. Come devono essere presentati i costi dei casi C medico-legali (vari anni di degenza)? Per il caso intero (intera durata di degenza) o solo per i costi del rispettivo anno solare e il resto tramite delimitazioni?
@@ -25,3 +26,4 @@ per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tutt
 - Le maggiorazioni dell'ANK non devono essere registrate nei conti 400 e 401. Tuttavia, devono essere inclusi nelle variabili totali dell'ANK (ktr_44_vkl / ktr_44_rekole). 
 - Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -23,7 +23,9 @@ Se l'organizzazione compila il SOMED, questi costi devono essere registrati in S
 3. Supplementi per i costi di utilizzo degli impianti (ANK) per i costi diretti: secondo REKOLE® , i supplementi ANK possono essere registrati 
 per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tuttavia, non esistono variabili ANK separate in SpiGes e nei dataset dei costi SwissDRG, a differenza delle spese generali, sulle quali è possibile registrare i costi di utilizzo degli impianti secondo REKOLE. In ITAR_K, i conti 400 e 401 devono essere specificati senza supplementi ANK. Cosa si deve fare con questi supplementi ANK sui conti 400 e 401?
 {{<collapsibleBlock groupId="kostentraeger">}}
+{{<markdown>}}
 - Le maggiorazioni dell'ANK non devono essere registrate nei conti 400 e 401. Tuttavia, devono essere inclusi nelle variabili totali dell'ANK (ktr_44_vkl / ktr_44_rekole). 
 - Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -22,8 +22,8 @@ Se l'organizzazione compila il SOMED, questi costi devono essere registrati in S
 3. Supplementi per i costi di utilizzo degli impianti (ANK) per i costi diretti: secondo REKOLE® , i supplementi ANK possono essere registrati 
 per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tuttavia, non esistono variabili ANK separate in SpiGes e nei dataset dei costi SwissDRG, a differenza delle spese generali, sulle quali è possibile registrare i costi di utilizzo degli impianti secondo REKOLE. In ITAR_K, i conti 400 e 401 devono essere specificati senza supplementi ANK. Cosa si deve fare con questi supplementi ANK sui conti 400 e 401?
 {{<collapsibleBlock groupId="kostentraeger">}}
-<ul>
-<li> Le maggiorazioni dell'ANK non devono essere registrate nei conti 400 e 401. Tuttavia, devono essere inclusi nelle variabili totali dell'ANK (ktr_44_vkl / ktr_44_rekole). </li>
-<li> Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. </li>
-</ul>
+
+- Le maggiorazioni dell'ANK non devono essere registrate nei conti 400 e 401. Tuttavia, devono essere inclusi nelle variabili totali dell'ANK (ktr_44_vkl / ktr_44_rekole). 
+- Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
+
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -11,17 +11,22 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
 {{<numberedList>}}
-1. Come devono essere presentati i costi dei casi C medico-legali (vari anni di degenza)? Per il caso intero (intera durata di degenza) o solo per i costi del rispettivo anno solare e il resto tramite delimitazioni?
+{{<listItem>}}
+Come devono essere presentati i costi dei casi C medico-legali (vari anni di degenza)? Per il caso intero (intera durata di degenza) o solo per i costi del rispettivo anno solare e il resto tramite delimitazioni?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Per i casi B e C, vanno indicati i costi per l’anno solare; per i casi A, i costi per l’intera durata del caso. Anche per le unità di imputazione ambulatoriali e quelle non legate a un caso, i costi si riferiscono all’anno solare. Si veda anche la colonna «Riferimento temporale» nell’elenco delle variabili. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. I casi di lungodegenza possono essere forniti in SpiGes con KTR tipo 101=lungodegenza come unità di costo indipendente dal caso, anche se il SOMED per l'assistenza di lungodegenza viene registrato in parallelo?
+{{<listItem>}}
+I casi di lungodegenza possono essere forniti in SpiGes con KTR tipo 101=lungodegenza come unità di costo indipendente dal caso, anche se il SOMED per l'assistenza di lungodegenza viene registrato in parallelo?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Se l'organizzazione compila il SOMED, questi costi devono essere registrati in SpiGes tramite il tipo KTR 101. Al contrario, i singoli casi di lunga durata in cure acute e riabilitazione (pazienti in attesa) devono essere mappati come tipo KTR 1 (=caso) e la corrispondente tariffa 7 (=tassa di cura). In questo modo si garantisce la correttezza dell'ITAR_K e delle statistiche.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Supplementi per i costi di utilizzo degli impianti (ANK) per i costi diretti: secondo REKOLE® , i supplementi ANK possono essere registrati 
+{{<listItem>}}
+Supplementi per i costi di utilizzo degli impianti (ANK) per i costi diretti: secondo REKOLE® , i supplementi ANK possono essere registrati 
 per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tuttavia, non esistono variabili ANK separate in SpiGes e nei dataset dei costi SwissDRG, a differenza delle spese generali, sulle quali è possibile registrare i costi di utilizzo degli impianti secondo REKOLE. In ITAR_K, i conti 400 e 401 devono essere specificati senza supplementi ANK. Cosa si deve fare con questi supplementi ANK sui conti 400 e 401?
 {{<collapsibleBlock groupId="kostentraeger">}}
 {{<markdown>}}
@@ -29,5 +34,7 @@ per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tutt
 - Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Falldaten/9_kostentrager_fall.md
+++ b/content/it/FAQ/Falldaten/9_kostentrager_fall.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="kostentraeger">}}
 
+{{<numberedList>}}
 1. Come devono essere presentati i costi dei casi C medico-legali (vari anni di degenza)? Per il caso intero (intera durata di degenza) o solo per i costi del rispettivo anno solare e il resto tramite delimitazioni?
 {{<collapsibleBlock groupId="kostentraeger">}}
 Per i casi B e C, vanno indicati i costi per l’anno solare; per i casi A, i costi per l’intera durata del caso. Anche per le unità di imputazione ambulatoriali e quelle non legate a un caso, i costi si riferiscono all’anno solare. Si veda anche la colonna «Riferimento temporale» nell’elenco delle variabili. 
@@ -28,4 +29,5 @@ per i costi diretti (requisiti medici 400 e 401). Per queste variabili KTR, tutt
 - Con la versione 1.4 dell'interfaccia, la variabile ktr_44_rekole viene convertita da variabile calcolata a variabile raccolta (e aggiunta all'XML), in modo da poter raccogliere un totale ANK REKOLE diverso dalla somma delle singole variabili KTR. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -11,29 +11,40 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 {{<numberedList>}}
 
-1. Che cos'è un secondo fattore di identificazione?
+{{<listItem>}}
+Che cos'è un secondo fattore di identificazione?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Il termine secondo fattore di identificazione si riferisce alla caratteristica di sicurezza da inserire in aggiunta al primo fattore di identificazione, che è la password CH-LOGIN.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. È possibile avere un solo CH-LOGIN per l'azienda/sede? 
+{{<listItem>}}
+È possibile avere un solo CH-LOGIN per l'azienda/sede? 
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 No, il CH-LOGIN è personale. Poiché la vostra identità deve essere verificata per accedere alla piattaforma SpiGes, è essenziale che il vostro account sia personale. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. C'è un cambio di dipendente nell'azienda/sede, è possibile trasferire il CH-LOGIN al nuovo dipendente?
+{{<listItem>}}
+C'è un cambio di dipendente nell'azienda/sede, è possibile trasferire il CH-LOGIN al nuovo dipendente?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 No, il CH-LOGIN è personale. Poiché la vostra identità deve essere verificata per accedere alla piattaforma SpiGes, è essenziale che il vostro account sia personale.  
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ho già un CH-LOGIN, devo crearne uno nuovo?
+{{<listItem>}}
+Ho già un CH-LOGIN, devo crearne uno nuovo?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 No, potete utilizzare il vostro CH-LOGIN. Tuttavia, è necessario impostare un secondo fattore di forza ed eseguire l'identificazione video lì, se non è ancora stato fatto sul vostro CH-LOGIN. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. La connessione con AGOV è possibile per l'applicazione SpiGes?
+{{<listItem>}}
+La connessione con AGOV è possibile per l'applicazione SpiGes?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non al momento.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -9,6 +9,7 @@ keywords: []
 
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
+{{<numberedList>}}
 
 1. Che cos'è un secondo fattore di identificazione?
 {{<collapsibleBlock groupId="CH_LOGIN">}}
@@ -34,5 +35,5 @@ No, potete utilizzare il vostro CH-LOGIN. Tuttavia, è necessario impostare un s
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non al momento.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
+++ b/content/it/FAQ/Onboarding_eIAM/1_CH_LOGIN.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="CH_LOGIN">}}
 
 1. Che cos'è un secondo fattore di identificazione?
@@ -33,3 +34,5 @@ No, potete utilizzare il vostro CH-LOGIN. Tuttavia, è necessario impostare un s
 {{<collapsibleBlock groupId="CH_LOGIN">}}
 Non al momento.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
+{{<numberedList>}}
 1. Quali fattori di sicurezza secondari posso utilizzare?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Per accedere alla piattaforma SpiGes è necessario un secondo fattore forte. Sono considerati forti i seguenti secondi fattori: Mobile ID e chiave FIDO. 
@@ -24,5 +25,5 @@ Sì, senza identificazione video non si raggiunge la QoA 50 (Qualità dell'auten
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Affinché un'identità elettronica sia considerata verificata, è necessario che un documento d'identità ufficiale con foto del titolare dell'identità elettronica sia stato controllato, registrato e che il titolare dell'identità elettronica sia stato correttamente identificato. A tal fine, è necessario sottoporsi al processo di identificazione video (VIPS) a pagamento (CHF 45.00), durante il quale l'identità viene verificata da una persona certificata.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 1. Quali fattori di sicurezza secondari posso utilizzare?
@@ -23,3 +24,5 @@ Sì, senza identificazione video non si raggiunge la QoA 50 (Qualità dell'auten
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Affinché un'identità elettronica sia considerata verificata, è necessario che un documento d'identità ufficiale con foto del titolare dell'identità elettronica sia stato controllato, registrato e che il titolare dell'identità elettronica sia stato correttamente identificato. A tal fine, è necessario sottoporsi al processo di identificazione video (VIPS) a pagamento (CHF 45.00), durante il quale l'identità viene verificata da una persona certificata.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
+++ b/content/it/FAQ/Onboarding_eIAM/2_sicherheitsfaktor.md
@@ -11,19 +11,26 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="Zweiter_sicherheitsfaktor">}}
 
 {{<numberedList>}}
-1. Quali fattori di sicurezza secondari posso utilizzare?
+{{<listItem>}}
+Quali fattori di sicurezza secondari posso utilizzare?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Per accedere alla piattaforma SpiGes è necessario un secondo fattore forte. Sono considerati forti i seguenti secondi fattori: Mobile ID e chiave FIDO. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. L'identificazione video è obbligatoria per l'utilizzo della piattaforma di indagine SpiGes?
+{{<listItem>}}
+L'identificazione video è obbligatoria per l'utilizzo della piattaforma di indagine SpiGes?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Sì, senza identificazione video non si raggiunge la QoA 50 (Qualità dell'autenticazione), necessaria per accedere alla piattaforma della rilevazione SpiGes. Per raggiungere questo livello di qualità dell'autenticazione, l'utente deve avere un'identità elettronica verificata e non solo autoregistrata.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Che cos'è un'identità verificata e cosa bisogna fare per ottenerla?
+{{<listItem>}}
+Che cos'è un'identità verificata e cosa bisogna fare per ottenerla?
 {{<collapsibleBlock groupId="Zweiter_sicherheitsfaktor">}}
 Affinché un'identità elettronica sia considerata verificata, è necessario che un documento d'identità ufficiale con foto del titolare dell'identità elettronica sia stato controllato, registrato e che il titolare dell'identità elettronica sia stato correttamente identificato. A tal fine, è necessario sottoporsi al processo di identificazione video (VIPS) a pagamento (CHF 45.00), durante il quale l'identità viene verificata da una persona certificata.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -11,24 +11,33 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 {{<numberedList>}}
-1. Non ho una carta SIM abbastanza recente da poter utilizzare Mobile ID, cosa posso fare?
+{{<listItem>}}
+Non ho una carta SIM abbastanza recente da poter utilizzare Mobile ID, cosa posso fare?
 {{<collapsibleBlock groupId="mobile_id">}}
 È possibile ordinare una carta SIM di ultima generazione presso il proprio gestore telefonico. È inoltre possibile utilizzare una chiave FIDO come secondo fattore di sicurezza. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Cosa fare se il telefono cellulare collegato al Mobile ID viene rubato/smarrito?
+{{<listItem>}}
+Cosa fare se il telefono cellulare collegato al Mobile ID viene rubato/smarrito?
 {{<collapsibleBlock groupId="mobile_id">}}
 Fate bloccare la vostra carta SIM dal vostro gestore di telefonia mobile. Questo bloccherà automaticamente il vostro Mobile ID. Non appena si dispone di una nuova carta SIM, è possibile riattivare il Mobile ID presso il proprio operatore di rete utilizzando il codice di riattivazione ricevuto al momento dell'attivazione del Mobile ID. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Posso utilizzare l'applicazione Mobile ID invece dell'attivazione con la carta SIM?
+{{<listItem>}}
+Posso utilizzare l'applicazione Mobile ID invece dell'attivazione con la carta SIM?
 {{<collapsibleBlock groupId="mobile_id">}}
 L'applicazione Mobile ID non è accettata come secondo fattore di sicurezza forte per il CH-LOGIN. 
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ho già un Mobile ID attivo, cosa devo fare?
+{{<listItem>}}
+Ho già un Mobile ID attivo, cosa devo fare?
 {{<collapsibleBlock groupId="mobile_id">}}
 Potete facilmente verificare se il vostro Mobile ID è attivo testandolo sul sito Mobile ID. Potete quindi seguire i passaggi per aggiungerlo come secondo fattore di sicurezza forte al vostro CH-LOGIN.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
+{{<numberedList>}}
 1. Non ho una carta SIM abbastanza recente da poter utilizzare Mobile ID, cosa posso fare?
 {{<collapsibleBlock groupId="mobile_id">}}
 È possibile ordinare una carta SIM di ultima generazione presso il proprio gestore telefonico. È inoltre possibile utilizzare una chiave FIDO come secondo fattore di sicurezza. 
@@ -29,5 +30,5 @@ L'applicazione Mobile ID non è accettata come secondo fattore di sicurezza fort
 {{<collapsibleBlock groupId="mobile_id">}}
 Potete facilmente verificare se il vostro Mobile ID è attivo testandolo sul sito Mobile ID. Potete quindi seguire i passaggi per aggiungerlo come secondo fattore di sicurezza forte al vostro CH-LOGIN.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
+++ b/content/it/FAQ/Onboarding_eIAM/3_mobile_id.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="mobile_id">}}
 
 1. Non ho una carta SIM abbastanza recente da poter utilizzare Mobile ID, cosa posso fare?
@@ -28,3 +29,5 @@ L'applicazione Mobile ID non è accettata come secondo fattore di sicurezza fort
 {{<collapsibleBlock groupId="mobile_id">}}
 Potete facilmente verificare se il vostro Mobile ID è attivo testandolo sul sito Mobile ID. Potete quindi seguire i passaggi per aggiungerlo come secondo fattore di sicurezza forte al vostro CH-LOGIN.
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/it/FAQ/Onboarding_eIAM/4_zugang.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="zugang">}}
 
+{{<numberedList>}}
 1. Il codice di onboarding scade dopo un certo periodo di tempo? Se sì, cosa devo fare se non sono riuscito a registrarmi in tempo? 
 {{<collapsibleBlock groupId="zugang">}}
 Chiedete alla persona competente del vostro cantone di inviarvi un'e-mail di onboarding.
@@ -29,4 +30,5 @@ Il primo punto di contatto è sempre la persona responsabile del vostro cantone.
 {{<collapsibleBlock groupId="zugang">}}
 No, purtroppo non sarà possibile utilizzare identità elettroniche diverse da quella indicata. Questo perché altre identità elettroniche non hanno una qualità di autenticazione sufficiente per l'utilizzo di SpiGes.
 {{</collapsibleBlock>}}
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/it/FAQ/Onboarding_eIAM/4_zugang.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="zugang">}}
 
 1. Il codice di onboarding scade dopo un certo periodo di tempo? Se sì, cosa devo fare se non sono riuscito a registrarmi in tempo? 
@@ -28,3 +29,4 @@ Il primo punto di contatto è sempre la persona responsabile del vostro cantone.
 {{<collapsibleBlock groupId="zugang">}}
 No, purtroppo non sarà possibile utilizzare identità elettroniche diverse da quella indicata. Questo perché altre identità elettroniche non hanno una qualità di autenticazione sufficiente per l'utilizzo di SpiGes.
 {{</collapsibleBlock>}}
+{{</faqBlock>}}

--- a/content/it/FAQ/Onboarding_eIAM/4_zugang.md
+++ b/content/it/FAQ/Onboarding_eIAM/4_zugang.md
@@ -11,24 +11,33 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="zugang">}}
 
 {{<numberedList>}}
-1. Il codice di onboarding scade dopo un certo periodo di tempo? Se sì, cosa devo fare se non sono riuscito a registrarmi in tempo? 
+{{<listItem>}}
+Il codice di onboarding scade dopo un certo periodo di tempo? Se sì, cosa devo fare se non sono riuscito a registrarmi in tempo? 
 {{<collapsibleBlock groupId="zugang">}}
 Chiedete alla persona competente del vostro cantone di inviarvi un'e-mail di onboarding.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Cosa devo fare se non lavoro più in ospedale? Posso cancellare il mio profilo?
+{{<listItem>}}
+Cosa devo fare se non lavoro più in ospedale? Posso cancellare il mio profilo?
 {{<collapsibleBlock groupId="zugang">}}
 Se non avete più bisogno di accedere alla piattaforma SpiGes, dovete contattare la persona responsabile nel vostro Cantone affinché possa revocare il vostro accesso alla piattaforma SpiGes. L'account CH-LOGIN e il secondo fattore di forza verificato sono personali, possono essere utilizzati per altre applicazioni dell'Amministrazione federale e non devono essere cancellati.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Chi posso contattare se il mio login non funziona?
+{{<listItem>}}
+Chi posso contattare se il mio login non funziona?
 {{<collapsibleBlock groupId="zugang">}}
 Il primo punto di contatto è sempre la persona responsabile del vostro cantone. Se non riuscite a trovare insieme una soluzione al vostro problema, potete contattare l'UST.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Ho un altro tipo di conto dell'Amministrazione federale, può essere utilizzato? 
+{{<listItem>}}
+Ho un altro tipo di conto dell'Amministrazione federale, può essere utilizzato? 
 {{<collapsibleBlock groupId="zugang">}}
 No, purtroppo non sarà possibile utilizzare identità elettroniche diverse da quella indicata. Questo perché altre identità elettroniche non hanno una qualità di autenticazione sufficiente per l'utilizzo di SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -16,10 +16,8 @@ Per domande di carattere specialistico o tecnico riguardanti SpiGes, l’ospedal
 
 2.	Quale sarà in futuro il ruolo dei Cantoni, in particolare dei partner cantonali di rilevazione?
 {{<collapsibleBlock groupId="roles">}}
-<ul>
-	<li> I servizi cantonali di rilevazione sono coinvolti nell’indagine UST come in precedenza (universo statistico, coordinamento e comunicazione con gli ospedali, solleciti ecc.).  </li>
-	<li> D’ora in poi il competente ufficio cantonale di sanità rilascerà a fine luglio i dati delle imprese ospedaliere presenti sul proprio territorio per l’utilizzo sulla piattaforma SpiGes, ai sensi della LAMal. </li>
-</ul>
+- I servizi cantonali di rilevazione sono coinvolti nell’indagine UST come in precedenza (universo statistico, coordinamento e comunicazione con gli ospedali, solleciti ecc.).
+- D’ora in poi il competente ufficio cantonale di sanità rilascerà a fine luglio i dati delle imprese ospedaliere presenti sul proprio territorio per l’utilizzo sulla piattaforma SpiGes, ai sensi della LAMal.
 {{</collapsibleBlock>}}
 
 3.	Sulla piattaforma SpiGes sono presenti variabili facoltative, che possono essere compilate secondo le indicazioni del Cantone. Entro quando il Cantone deve informare le imprese o l’UST in merito alle variabili che devono essere compilate? Il Cantone è libero di decidere quali tra gli elementi facoltativi debbano essere completati?

--- a/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="roles">}}
 
 1.	A chi si rivolge l’ospedale in caso di domande sul contenuto della rilevazione SpiGes?
@@ -40,3 +41,4 @@ L’UST è in contatto con l’ANQ per armonizzare le variabili e i formati SpiG
 Conformemente all’art. 23 della legge federale del 18 marzo 1994 sull’assicurazione malattie (LAMal; RS 832.10), art. 6 cpv. 4 della legge del 9 ottobre 1992 sulla statistica federale (LStat; RS 431.01), art. 6 cpv. 1 dell’ordinanza del 30 giugno 1993 sull’esecuzione di rilevazioni statistiche federali (RS 431. 012.1) e le disposizioni sulla statistica ospedaliera e sulla statistica medica nell’allegato di detta ordinanza tutti gli ospedali sono tenuti a fornire i dati necessari all’Ufficio federale di statistica nella forma legalmente prescritta e entro il termine fissato.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -11,37 +11,50 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="roles">}}
 
 {{<numberedList>}}
-1.	A chi si rivolge l’ospedale in caso di domande sul contenuto della rilevazione SpiGes?
+{{<listItem>}}
+A chi si rivolge l’ospedale in caso di domande sul contenuto della rilevazione SpiGes?
 {{<collapsibleBlock groupId="roles">}}
 Per domande di carattere specialistico o tecnico riguardanti SpiGes, l’ospedale deve rivolgersi in primo luogo al servizio di rilevazione cantonale competente.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2.	Quale sarà in futuro il ruolo dei Cantoni, in particolare dei partner cantonali di rilevazione?
+{{<listItem>}}
+Quale sarà in futuro il ruolo dei Cantoni, in particolare dei partner cantonali di rilevazione?
 {{<collapsibleBlock groupId="roles">}}
 {{<markdown>}}
 - I servizi cantonali di rilevazione sono coinvolti nell’indagine UST come in precedenza (universo statistico, coordinamento e comunicazione con gli ospedali, solleciti ecc.).
 - D’ora in poi il competente ufficio cantonale di sanità rilascerà a fine luglio i dati delle imprese ospedaliere presenti sul proprio territorio per l’utilizzo sulla piattaforma SpiGes, ai sensi della LAMal.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3.	Sulla piattaforma SpiGes sono presenti variabili facoltative, che possono essere compilate secondo le indicazioni del Cantone. Entro quando il Cantone deve informare le imprese o l’UST in merito alle variabili che devono essere compilate? Il Cantone è libero di decidere quali tra gli elementi facoltativi debbano essere completati?
+{{<listItem>}}
+Sulla piattaforma SpiGes sono presenti variabili facoltative, che possono essere compilate secondo le indicazioni del Cantone. Entro quando il Cantone deve informare le imprese o l’UST in merito alle variabili che devono essere compilate? Il Cantone è libero di decidere quali tra gli elementi facoltativi debbano essere completati?
 {{<collapsibleBlock groupId="roles">}}
 I Cantoni informano i loro ospedali di preparare le variabili facoltative (ad es. op_gln) con sufficiente anticipo, in modo che queste vengano registrate nel sistema ospedaliero a partire dai dati del 2024. Il Cantone decide in base alle proprie linee guida nel settore sanitario, quali di queste variabili possono essere più specifiche rispetto alle linee guida nazionali.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4.	Gli ospedali auspicano l’organizzazione di un incontro informativo in modo da acquisire una migliore visione delle esigenze future. L’UST prevede di organizzare un evento del genere?
+{{<listItem>}}
+Gli ospedali auspicano l’organizzazione di un incontro informativo in modo da acquisire una migliore visione delle esigenze future. L’UST prevede di organizzare un evento del genere?
 {{<collapsibleBlock groupId="roles">}}
 L’UST ha già svolto quattro eventi informativi per un vasto pubblico, a cui hanno partecipato anche alcuni ospedali. H+ ne ha di volta in volta informato i suoi ospedali. Poiché le domande che sorgono attualmente non sono più di natura concettuale bensì su argomenti ben specifici, l’UST ritiene che un evento su ampia scala non sia lo strumento adatto per rispondere a queste nuove esigenze. L’UST raccoglie le diverse domande che le sono state rivolte e le pubblicherà sul sito web dello SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. In futuro sarà possibile soddisfare anche i requisiti dell’ANQ con il file XML?
+{{<listItem>}}
+In futuro sarà possibile soddisfare anche i requisiti dell’ANQ con il file XML?
 {{<collapsibleBlock groupId="roles">}}
 L’UST è in contatto con l’ANQ per armonizzare le variabili e i formati SpiGes.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6.	Qual è la base giuridica che obbliga gli ospedali a trasmettere la statistica?
+{{<listItem>}}
+Qual è la base giuridica che obbliga gli ospedali a trasmettere la statistica?
 {{<collapsibleBlock groupId="roles">}}
 Conformemente all’art. 23 della legge federale del 18 marzo 1994 sull’assicurazione malattie (LAMal; RS 832.10), art. 6 cpv. 4 della legge del 9 ottobre 1992 sulla statistica federale (LStat; RS 431.01), art. 6 cpv. 1 dell’ordinanza del 30 giugno 1993 sull’esecuzione di rilevazioni statistiche federali (RS 431. 012.1) e le disposizioni sulla statistica ospedaliera e sulla statistica medica nell’allegato di detta ordinanza tutti gli ospedali sono tenuti a fornire i dati necessari all’Ufficio federale di statistica nella forma legalmente prescritta e entro il termine fissato.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="roles">}}
 
+{{<numberedList>}}
 1.	A chi si rivolge l’ospedale in caso di domande sul contenuto della rilevazione SpiGes?
 {{<collapsibleBlock groupId="roles">}}
 Per domande di carattere specialistico o tecnico riguardanti SpiGes, l’ospedale deve rivolgersi in primo luogo al servizio di rilevazione cantonale competente.
@@ -42,5 +43,5 @@ L’UST è in contatto con l’ANQ per armonizzare le variabili e i formati SpiG
 {{<collapsibleBlock groupId="roles">}}
 Conformemente all’art. 23 della legge federale del 18 marzo 1994 sull’assicurazione malattie (LAMal; RS 832.10), art. 6 cpv. 4 della legge del 9 ottobre 1992 sulla statistica federale (LStat; RS 431.01), art. 6 cpv. 1 dell’ordinanza del 30 giugno 1993 sull’esecuzione di rilevazioni statistiche federali (RS 431. 012.1) e le disposizioni sulla statistica ospedaliera e sulla statistica medica nell’allegato di detta ordinanza tutti gli ospedali sono tenuti a fornire i dati necessari all’Ufficio federale di statistica nella forma legalmente prescritta e entro il termine fissato.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
+++ b/content/it/FAQ/allgemeine_angaben/1_rollen_stakeholder.md
@@ -17,8 +17,10 @@ Per domande di carattere specialistico o tecnico riguardanti SpiGes, l’ospedal
 
 2.	Quale sarà in futuro il ruolo dei Cantoni, in particolare dei partner cantonali di rilevazione?
 {{<collapsibleBlock groupId="roles">}}
+{{<markdown>}}
 - I servizi cantonali di rilevazione sono coinvolti nell’indagine UST come in precedenza (universo statistico, coordinamento e comunicazione con gli ospedali, solleciti ecc.).
 - D’ora in poi il competente ufficio cantonale di sanità rilascerà a fine luglio i dati delle imprese ospedaliere presenti sul proprio territorio per l’utilizzo sulla piattaforma SpiGes, ai sensi della LAMal.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3.	Sulla piattaforma SpiGes sono presenti variabili facoltative, che possono essere compilate secondo le indicazioni del Cantone. Entro quando il Cantone deve informare le imprese o l’UST in merito alle variabili che devono essere compilate? Il Cantone è libero di decidere quali tra gli elementi facoltativi debbano essere completati?

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
+{{<numberedList>}}
 1. Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
@@ -65,5 +66,5 @@ Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elench
 {{<collapsibleBlock groupId="contenu">}}
 Come si può vedere dallo schema XML, queste variabili calcolate non sono incluse. È possibile ignorarle.
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -12,6 +12,7 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
+{{<markdown>}}
 - SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
     - il trattamento principale è abolito; 
 	- il complemento alla diagnosi principale è abolito; 
@@ -21,12 +22,15 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 	- la relazione tra più diagnosi (croce/asterisco, punto esclamativo) viene ora registrata con una variabile di riferimento (diagnose_zusatz) anziché con il carattere speciale. 
 - Il modo migliore per tenere traccia di tutte le modifiche apportate al set di dati e dei dettagli esatti è quello di esaminare l’elenco delle variabili e filtrare la colonna «Nuova / Variabile MS» secondo le variabili nuove e quelle adattate. 
 - Da ora i dati delle fatture e i costi o i ricavi vengono raccolti per ogni caso. 
-- Il set di dati completo è disponibile qui: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html </a>
+- Il set di dati completo è disponibile qui: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html)
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Che ripercussioni ha SpiGes sulle direttive di codifica?
 {{<collapsibleBlock groupId="contenu">}}
-Queste informazioni sono riportate nel Manuale di codifica, scaricabile al link seguente:  <a href="https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html"> https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html </a>
+{{<markdown>}}
+Queste informazioni sono riportate nel Manuale di codifica, scaricabile al link seguente: [https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html](https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 3. Qual è il contenuto del rapporto di verifica?
@@ -36,12 +40,15 @@ Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono a
 
 4. Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
 {{<collapsibleBlock groupId="contenu">}}
+{{<markdown>}}
 - I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   
 - Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova. 
 - A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
-5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 		
+5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 
+{{<markdown>}}		
 Statistiche MS:         
 0 = nato morto          
 1 = nato vivo           	
@@ -49,6 +56,7 @@ SpiGes (al contrario):
 0 = nato vivo               
 1 = nato morto          
 Altri esempi potrebbero essere l'istruzione scolastica o lo stato civile. A nostro avviso, questo non è l'ideale e vorremmo sapere se questa è l'intenzione e, in caso affermativo, perché? 
+{{</markdown>}}
 {{<collapsibleBlock groupId="contenu">}}
 Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elenchi di codici e i metadati in un sistema UST, che sarà poi pubblicato. I nuovi elenchi di codici corrispondono ora allo standard svizzero della piattaforma di interoperabilità i14y.admin.ch; in precedenza si trattava di una soluzione speciale di MS.
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,25 +11,18 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
-<ul>
-<li> SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
-<ul>
-<li> 	il trattamento principale è abolito; </li>
-<li>	il complemento alla diagnosi principale è abolito; </li>
-<li>	novità: è possibile registrare un numero illimitato di diagnosi e trattamenti; </li>
-<li>	il tempo di prestazione medica chirurgica viene registrato sotto procedure chirurgiche; </li>
-<li>	per le procedure chirurgiche, l’inizio del trattamento deve essere registrato con l’ora (dell’operazione nel suo complesso); </li>
-<li>	la relazione tra più diagnosi (croce/asterisco, punto esclamativo) viene ora registrata con una variabile di riferimento (diagnose_zusatz) anziché con il carattere speciale. </li>
-</ul>
-</li>
 
-<li>	Il modo migliore per tenere traccia di tutte le modifiche apportate al set di dati e dei dettagli esatti è quello di esaminare l’elenco delle variabili e filtrare la colonna «Nuova / Variabile MS» secondo le variabili nuove e quelle adattate. </li>
+- SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
 
-<li> Da ora i dati delle fatture e i costi o i ricavi vengono raccolti per ogni caso. </li>
-
-<li> Il set di dati completo è disponibile qui: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html </a>
-</li>
-</ul>
+    - il trattamento principale è abolito; 
+	- il complemento alla diagnosi principale è abolito; 
+	- novità: è possibile registrare un numero illimitato di diagnosi e trattamenti; 
+	- il tempo di prestazione medica chirurgica viene registrato sotto procedure chirurgiche; 
+	- per le procedure chirurgiche, l’inizio del trattamento deve essere registrato con l’ora (dell’operazione nel suo complesso); 
+	- la relazione tra più diagnosi (croce/asterisco, punto esclamativo) viene ora registrata con una variabile di riferimento (diagnose_zusatz) anziché con il carattere speciale. 
+- Il modo migliore per tenere traccia di tutte le modifiche apportate al set di dati e dei dettagli esatti è quello di esaminare l’elenco delle variabili e filtrare la colonna «Nuova / Variabile MS» secondo le variabili nuove e quelle adattate. 
+- Da ora i dati delle fatture e i costi o i ricavi vengono raccolti per ogni caso. 
+- Il set di dati completo è disponibile qui: <a href="https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html"> https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html </a>
 {{</collapsibleBlock>}}
 
 2. Che ripercussioni ha SpiGes sulle direttive di codifica?
@@ -44,11 +37,11 @@ Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono a
 
 4. Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
 {{<collapsibleBlock groupId="contenu">}}
-<ul>
-<li> I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   </li>
-<li> Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova. </li>
-<li> A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. </li>
-</ul>
+
+- I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   
+- Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova. 
+- A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. 
+
 {{</collapsibleBlock>}}
 
 5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,9 +11,7 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
-
 - SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
-
     - il trattamento principale è abolito; 
 	- il complemento alla diagnosi principale è abolito; 
 	- novità: è possibile registrare un numero illimitato di diagnosi e trattamenti; 
@@ -37,23 +35,18 @@ Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono a
 
 4. Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
 {{<collapsibleBlock groupId="contenu">}}
-
 - I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   
 - Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova. 
 - A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. 
-
 {{</collapsibleBlock>}}
 
-5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 
-
+5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 		
 Statistiche MS:         
 0 = nato morto          
-1 = nato vivo           
-
+1 = nato vivo           	
 SpiGes (al contrario):            
 0 = nato vivo               
 1 = nato morto          
-
 Altri esempi potrebbero essere l'istruzione scolastica o lo stato civile. A nostro avviso, questo non è l'ideale e vorremmo sapere se questa è l'intenzione e, in caso affermativo, perché? 
 {{<collapsibleBlock groupId="contenu">}}
 Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elenchi di codici e i metadati in un sistema UST, che sarà poi pubblicato. I nuovi elenchi di codici corrispondono ora allo standard svizzero della piattaforma di interoperabilità i14y.admin.ch; in precedenza si trattava di una soluzione speciale di MS.

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 1. Quali variabili cambiano con SpiGes?
@@ -57,3 +58,4 @@ Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elench
 Come si può vedere dallo schema XML, queste variabili calcolate non sono incluse. È possibile ignorarle.
 {{</collapsibleBlock>}}
 
+{{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -11,7 +11,8 @@ keywords: []
 Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 
 {{<numberedList>}}
-1. Quali variabili cambiano con SpiGes?
+{{<listItem>}}
+Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 - SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
@@ -26,20 +27,26 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 - Il set di dati completo è disponibile qui: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Che ripercussioni ha SpiGes sulle direttive di codifica?
+{{<listItem>}}
+Che ripercussioni ha SpiGes sulle direttive di codifica?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 Queste informazioni sono riportate nel Manuale di codifica, scaricabile al link seguente: [https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html](https://www.bfs.admin.ch/bfs/it/home/statistiche/salute/nomenclature/medkk.html).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Qual è il contenuto del rapporto di verifica?
+{{<listItem>}}
+Qual è il contenuto del rapporto di verifica?
 {{<collapsibleBlock groupId="contenu">}}
 Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono attualmente in fase di elaborazione all’interno di un gruppo di lavoro in cui sono rappresentati tutti gli stakeholder. In sostanza, il rapporto di verifica contiene tutte le verifiche che sono state avviate e le motivazioni ufficiali relative a tali verifiche (un estratto della chat relativa alla verifica).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
+{{<listItem>}}
+Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
 - I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   
@@ -47,8 +54,10 @@ Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono a
 - A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 
+{{<listItem>}}
+Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 
 {{<markdown>}}		
 Statistiche MS:         
 0 = nato morto          
@@ -61,10 +70,14 @@ Altri esempi potrebbero essere l'istruzione scolastica o lo stato civile. A nost
 {{<collapsibleBlock groupId="contenu">}}
 Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elenchi di codici e i metadati in un sistema UST, che sarà poi pubblicato. I nuovi elenchi di codici corrispondono ora allo standard svizzero della piattaforma di interoperabilità i14y.admin.ch; in precedenza si trattava di una soluzione speciale di MS.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Valori calcolati: Nell'elenco delle variabili ci sono alcune righe che sono "oscurate" con il commento "calcolato" (ad esempio uid). Significa che dobbiamo fornirle vuote nell'XML e che l'UST le calcolerà e le inserirà? Oppure non dobbiamo fornire affatto questi valori e ignorarli? 
+{{<listItem>}}
+Valori calcolati: Nell'elenco delle variabili ci sono alcune righe che sono "oscurate" con il commento "calcolato" (ad esempio uid). Significa che dobbiamo fornirle vuote nell'XML e che l'UST le calcolerà e le inserirà? Oppure non dobbiamo fornire affatto questi valori e ignorarli? 
 {{<collapsibleBlock groupId="contenu">}}
 Come si può vedere dallo schema XML, queste variabili calcolate non sono incluse. È possibile ignorarle.
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
+++ b/content/it/FAQ/allgemeine_angaben/2_inhaltliche_anpassungen.md
@@ -15,15 +15,16 @@ Ouvrir toutes les questions: {{<collapsibleGroupCommand groupId="contenu">}}
 Quali variabili cambiano con SpiGes?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
+
 - SpiGes ha un impatto importante sul processo di verifica e sul formato dei dati contenuti nella fornitura. Per quanto riguarda i dati medici (attuale MS ), cambiano solo pochi punti. I più importanti sono probabilmente i seguenti:
-    - il trattamento principale è abolito; 
-	- il complemento alla diagnosi principale è abolito; 
-	- novità: è possibile registrare un numero illimitato di diagnosi e trattamenti; 
-	- il tempo di prestazione medica chirurgica viene registrato sotto procedure chirurgiche; 
-	- per le procedure chirurgiche, l’inizio del trattamento deve essere registrato con l’ora (dell’operazione nel suo complesso); 
-	- la relazione tra più diagnosi (croce/asterisco, punto esclamativo) viene ora registrata con una variabile di riferimento (diagnose_zusatz) anziché con il carattere speciale. 
-- Il modo migliore per tenere traccia di tutte le modifiche apportate al set di dati e dei dettagli esatti è quello di esaminare l’elenco delle variabili e filtrare la colonna «Nuova / Variabile MS» secondo le variabili nuove e quelle adattate. 
-- Da ora i dati delle fatture e i costi o i ricavi vengono raccolti per ogni caso. 
+    - il trattamento principale è abolito;
+   	- il complemento alla diagnosi principale è abolito;
+   	- novità: è possibile registrare un numero illimitato di diagnosi e trattamenti;
+   	- il tempo di prestazione medica chirurgica viene registrato sotto procedure chirurgiche;
+   	- per le procedure chirurgiche, l’inizio del trattamento deve essere registrato con l’ora (dell’operazione nel suo complesso);
+   	- la relazione tra più diagnosi (croce/asterisco, punto esclamativo) viene ora registrata con una variabile di riferimento (diagnose_zusatz) anziché con il carattere speciale.
+- Il modo migliore per tenere traccia di tutte le modifiche apportate al set di dati e dei dettagli esatti è quello di esaminare l’elenco delle variabili e filtrare la colonna «Nuova / Variabile MS» secondo le variabili nuove e quelle adattate.
+- Da ora i dati delle fatture e i costi o i ricavi vengono raccolti per ogni caso.
 - Il set di dati completo è disponibile qui: [https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html](https://www.bfs.admin.ch/bfs/fr/home/statistiques/sante/systeme-sante/projet-spiges.assetdetail.25885643.html)
 {{</markdown>}}
 {{</collapsibleBlock>}}
@@ -49,23 +50,24 @@ Il contenuto esatto del rapporto di verifica dipende dalle verifiche, che sono a
 Gli ospedali che fanno parte della fase pilota del progetto potranno creare un "set di dati" iniziale già nella primavera del 2024. Altri cantoni richiedono l'invio di un file di dati XML iniziale entro settembre. Per questi invii sono attesi i dati reali di un sistema produttivo o sono sufficienti i dati di un sistema di prova? In altre parole: la valutazione "reale" inizierà solo nel 2025 o l'UST vuole valutare anche i dati reali del 2024?
 {{<collapsibleBlock groupId="contenu">}}
 {{<markdown>}}
-- I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.   
-- Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova. 
-- A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile. 
+
+- I dati reali di un sistema produttivo sono attesi dagli ospedali che fanno parte della fase pilota del progetto nella primavera del 2024. Questi dati saranno analizzati solo per ottenere informazioni sul progetto pilota.
+- Entro agosto 2024, tutti gli ospedali (in tutti i cantoni) devono effettuare un test dell'interfaccia per dimostrare che l'implementazione tecnica dell'interfaccia funziona. A tal fine sono sufficienti anche le consegne parziali dei sistemi di prova.
+- A partire dal 1° gennaio 2025, tutti gli ospedali devono fornire i dati reali per il 2024 dai sistemi di produzione e verificarli completamente e, se necessario, giustificarli entro la fine di aprile.
 {{</markdown>}}
 {{</collapsibleBlock>}}
 {{</listItem>}}
 
 {{<listItem>}}
-Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale. 
+Valori scambiati: Abbiamo notato che i valori di alcune variabili sono diversi dalle statistiche MS. Un esempio è il valore del segno vitale.
 {{<markdown>}}		
-Statistiche MS:         
-0 = nato morto          
-1 = nato vivo           	
-SpiGes (al contrario):            
-0 = nato vivo               
-1 = nato morto          
-Altri esempi potrebbero essere l'istruzione scolastica o lo stato civile. A nostro avviso, questo non è l'ideale e vorremmo sapere se questa è l'intenzione e, in caso affermativo, perché? 
+Statistiche MS:
+0 = nato morto
+1 = nato vivo
+SpiGes (al contrario):
+0 = nato vivo
+1 = nato morto
+Altri esempi potrebbero essere l'istruzione scolastica o lo stato civile. A nostro avviso, questo non è l'ideale e vorremmo sapere se questa è l'intenzione e, in caso affermativo, perché?
 {{</markdown>}}
 {{<collapsibleBlock groupId="contenu">}}
 Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elenchi di codici e i metadati in un sistema UST, che sarà poi pubblicato. I nuovi elenchi di codici corrispondono ora allo standard svizzero della piattaforma di interoperabilità i14y.admin.ch; in precedenza si trattava di una soluzione speciale di MS.
@@ -73,7 +75,7 @@ Questa è l'intenzione. Nello spirito di once only, abbiamo integrato gli elench
 {{</listItem>}}
 
 {{<listItem>}}
-Valori calcolati: Nell'elenco delle variabili ci sono alcune righe che sono "oscurate" con il commento "calcolato" (ad esempio uid). Significa che dobbiamo fornirle vuote nell'XML e che l'UST le calcolerà e le inserirà? Oppure non dobbiamo fornire affatto questi valori e ignorarli? 
+Valori calcolati: Nell'elenco delle variabili ci sono alcune righe che sono "oscurate" con il commento "calcolato" (ad esempio uid). Significa che dobbiamo fornirle vuote nell'XML e che l'UST le calcolerà e le inserirà? Oppure non dobbiamo fornire affatto questi valori e ignorarli?
 {{<collapsibleBlock groupId="contenu">}}
 Come si può vedere dallo schema XML, queste variabili calcolate non sono incluse. È possibile ignorarle.
 {{</collapsibleBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -21,7 +21,7 @@ In merito all’introduzione di SpiGes o al momento di definire l’universo sta
 {{</collapsibleBlock>}}
 {{</listItem>}}
 
-{{</listItem>}}
+{{<listItem>}}
 Che differenza c’è tra un’impresa ospedaliera, un ospedale e una sede ospedaliera?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,19 +11,15 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1.	In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> In occasione della prima rilevazione SpiGes (dati 2024), nel 2025, verrà ancora fatta un’importazione manuale dell’universo statistico KS  sotto forma di elenchi Excel. </li>
-<li> Il precedente BUR  si chiamerà BURGESV  e rimarrà l’identificatore dell’ospedale. A partire dai dati 2024 (per la rilevazione 2025) il BUR-sede del trattamento sarà chiamato BUR.  </li>
-</ul>
+- In occasione della prima rilevazione SpiGes (dati 2024), nel 2025, verrà ancora fatta un’importazione manuale dell’universo statistico KS  sotto forma di elenchi Excel.
+- Il precedente BUR  si chiamerà BURGESV  e rimarrà l’identificatore dell’ospedale. A partire dai dati 2024 (per la rilevazione 2025) il BUR-sede del trattamento sarà chiamato BUR. 
 {{</collapsibleBlock>}}
 
 2. Che differenza c’è tra un’impresa ospedaliera, un ospedale e una sede ospedaliera?
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> Un’impresa ospedaliera è un’impresa con il codice NOGA 861001 (ospedali generali), 861002 (cliniche specializzate) o 869004 (case di maternità). È designato in modo univoco attraverso il numero di identificazione ENTID.  </li>
-<li> Nell’indagine SpiGes, l’ospedale è un’unità che compila un ITAR_K® e su cui si basa la definizione dei casi di secondo SwissDRG AG. Un ospedale è contrassegnato con il numero RIS GESV, che è presente solo nella banca dati di GESV. </li>
-<li> Una sede di ospedale è contrassegnata in modo univoco con il numero RIS e fa sempre capo a un’impresa ospedaliera ben precisa.  </li>
-</ul>
+- Un’impresa ospedaliera è un’impresa con il codice NOGA 861001 (ospedali generali), 861002 (cliniche specializzate) o 869004 (case di maternità). È designato in modo univoco attraverso il numero di identificazione ENTID. 
+- Nell’indagine SpiGes, l’ospedale è un’unità che compila un ITAR_K® e su cui si basa la definizione dei casi di secondo SwissDRG AG. Un ospedale è contrassegnato con il numero RIS GESV, che è presente solo nella banca dati di GESV.
+- Una sede di ospedale è contrassegnata in modo univoco con il numero RIS e fa sempre capo a un’impresa ospedaliera ben precisa. 
 La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (BURGESV)  e 14 sedi (RIS) :
 {{<insertImage image="tableauFAQ1_it.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
@@ -56,10 +52,8 @@ La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (B
 
 4. Come si determina a quale ospedale (burnr_gesv) appartiene una sede (burnr)? 
 {{<collapsibleBlock groupId="GGH">}}
-<ul>
-<li> L’attribuzione delle sedi (numeri BUR) agli ospedali (BUR-GESV) viene rilevata nel quadro della rilevazione dell’universo statistico. In questo processo, sono i Cantoni a fornirci le informazioni in collaborazione con gli ospedali. </li>
-<li> Il burnr_gesv viene rilevato anche su richiesta dei nostri partner. </li>
-</ul>
+- L’attribuzione delle sedi (numeri BUR) agli ospedali (BUR-GESV) viene rilevata nel quadro della rilevazione dell’universo statistico. In questo processo, sono i Cantoni a fornirci le informazioni in collaborazione con gli ospedali.
+- Il burnr_gesv viene rilevato anche su richiesta dei nostri partner.
 {{</collapsibleBlock>}}
 
 5. Cosa si intende per Centro di prestazione medica principale (ad es. M000, M050)?

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1.	In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
@@ -65,3 +66,5 @@ Un centro di prestazione è un’unità organizzativa di un ospedale nella quale
 {{<collapsibleBlock groupId="GGH">}}
 Sì, un caso viene sempre registrato in una sola sede, ossia la sede principale (vedere la variabile burnr).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -12,16 +12,20 @@ Aprire tutte le domande: {{<collapsibleGroupCommand groupId="GGH">}}
 
 1.	In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - In occasione della prima rilevazione SpiGes (dati 2024), nel 2025, verrà ancora fatta un’importazione manuale dell’universo statistico KS  sotto forma di elenchi Excel.
 - Il precedente BUR  si chiamerà BURGESV  e rimarrà l’identificatore dell’ospedale. A partire dai dati 2024 (per la rilevazione 2025) il BUR-sede del trattamento sarà chiamato BUR. 
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 2. Che differenza c’è tra un’impresa ospedaliera, un ospedale e una sede ospedaliera?
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - Un’impresa ospedaliera è un’impresa con il codice NOGA 861001 (ospedali generali), 861002 (cliniche specializzate) o 869004 (case di maternità). È designato in modo univoco attraverso il numero di identificazione ENTID. 
 - Nell’indagine SpiGes, l’ospedale è un’unità che compila un ITAR_K® e su cui si basa la definizione dei casi di secondo SwissDRG AG. Un ospedale è contrassegnato con il numero RIS GESV, che è presente solo nella banca dati di GESV.
 - Una sede di ospedale è contrassegnata in modo univoco con il numero RIS e fa sempre capo a un’impresa ospedaliera ben precisa. 
 La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (BURGESV)  e 14 sedi (RIS) :
+{{</markdown>}}
 {{<insertImage image="tableauFAQ1_it.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
 
@@ -53,8 +57,10 @@ La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (B
 
 4. Come si determina a quale ospedale (burnr_gesv) appartiene una sede (burnr)? 
 {{<collapsibleBlock groupId="GGH">}}
+{{<markdown>}}
 - L’attribuzione delle sedi (numeri BUR) agli ospedali (BUR-GESV) viene rilevata nel quadro della rilevazione dell’universo statistico. In questo processo, sono i Cantoni a fornirci le informazioni in collaborazione con gli ospedali.
 - Il burnr_gesv viene rilevato anche su richiesta dei nostri partner.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. Cosa si intende per Centro di prestazione medica principale (ad es. M000, M050)?

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -11,15 +11,18 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="GGH">}}
 
 {{<numberedList>}}
-1.	In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
+{{<listItem>}}
+In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - In occasione della prima rilevazione SpiGes (dati 2024), nel 2025, verrà ancora fatta un’importazione manuale dell’universo statistico KS  sotto forma di elenchi Excel.
 - Il precedente BUR  si chiamerà BURGESV  e rimarrà l’identificatore dell’ospedale. A partire dai dati 2024 (per la rilevazione 2025) il BUR-sede del trattamento sarà chiamato BUR. 
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Che differenza c’è tra un’impresa ospedaliera, un ospedale e una sede ospedaliera?
+{{</listItem>}}
+Che differenza c’è tra un’impresa ospedaliera, un ospedale e una sede ospedaliera?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - Un’impresa ospedaliera è un’impresa con il codice NOGA 861001 (ospedali generali), 861002 (cliniche specializzate) o 869004 (case di maternità). È designato in modo univoco attraverso il numero di identificazione ENTID. 
@@ -29,8 +32,10 @@ La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (B
 {{</markdown>}}
 {{<insertImage image="tableauFAQ1_it.png"  class="max-w-90">}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. Quali termini sono usati come sinonimi nell’indagine SpiGes per impresa ospedaliera, ospedale e sede?
+{{<listItem>}}
+Quali termini sono usati come sinonimi nell’indagine SpiGes per impresa ospedaliera, ospedale e sede?
 {{<collapsibleBlock groupId="GGH">}}
 <table class="w-100">
   <tr>
@@ -55,23 +60,31 @@ La tabella seguente mostra un esempio di impresa (UID/ENTID)  con 12 ospedali (B
   </tr>
 </table>
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Come si determina a quale ospedale (burnr_gesv) appartiene una sede (burnr)? 
+{{<listItem>}}
+Come si determina a quale ospedale (burnr_gesv) appartiene una sede (burnr)? 
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
 - L’attribuzione delle sedi (numeri BUR) agli ospedali (BUR-GESV) viene rilevata nel quadro della rilevazione dell’universo statistico. In questo processo, sono i Cantoni a fornirci le informazioni in collaborazione con gli ospedali.
 - Il burnr_gesv viene rilevato anche su richiesta dei nostri partner.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. Cosa si intende per Centro di prestazione medica principale (ad es. M000, M050)?
+{{<listItem>}}
+Cosa si intende per Centro di prestazione medica principale (ad es. M000, M050)?
 {{<collapsibleBlock groupId="GGH">}}
 Un centro di prestazione è un’unità organizzativa di un ospedale nella quale sono erogate prestazioni mediche, medico-tecniche o medico-terapeutiche. Nell’indagine SpiGes viene richiesto il centro di prestazione medica principale in cui il paziente è in cura.  
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Se un ospedale ha diverse sedi, un caso viene sempre registrato in una sola sede, anche se è stato trasferito da una sede a un'altra sede dello stesso ospedale?
+{{<listItem>}}
+Se un ospedale ha diverse sedi, un caso viene sempre registrato in una sola sede, anche se è stato trasferito da una sede a un'altra sede dello stesso ospedale?
 {{<collapsibleBlock groupId="GGH">}}
 Sì, un caso viene sempre registrato in una sola sede, ossia la sede principale (vedere la variabile burnr).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
+++ b/content/it/FAQ/allgemeine_angaben/3_grundgesamtheit_erhebungseinheiten.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="GGH">}}
 
+{{<numberedList>}}
 1.	In merito all’introduzione di SpiGes o al momento di definire l’universo statistico per la prima rilevazione SpiGes, si utilizzeranno ancora i vecchi «elenchi ospedalieri» o si lavorerà già con SpiReg?
 {{<collapsibleBlock groupId="GGH">}}
 {{<markdown>}}
@@ -72,5 +73,5 @@ Un centro di prestazione è un’unità organizzativa di un ospedale nella quale
 {{<collapsibleBlock groupId="GGH">}}
 Sì, un caso viene sempre registrato in una sola sede, ossia la sede principale (vedere la variabile burnr).
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -7,6 +7,7 @@ type: docs
 keywords: []
 ---
 
+{{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 1. Nel quadro della SpiGes sono rilevate solo informazioni in merito ai casi di cure stazionarie. Come deve essere compilata la parte dell’ITAR_K® riservata alle cure ambulatoriali?
@@ -40,3 +41,5 @@ Entro questa scadenza, i dati sui costi dovranno essere stati controllati automa
 {{<collapsibleBlock groupId="ITARK">}}
 Lo strumento centrale per la tariffazione e l'audit delle prestazioni sarà creato in futuro da SpiGes. Per garantire una transizione sicura e corretta, per la creazione di ITAR_K® è previsto il funzionamento parallelo della vecchia e della nuova piattaforma (rispettivamente H+ e SpiGes). Nel 2025 (dati 2024), l'ITAR_K® ufficiale continuerà a essere creato dalla piattaforma H+ come in precedenza. A partire da settembre 2025, tutti gli ospedali avranno anche la possibilità di creare l'ITAR_K® 2025 (dati 2024) tramite SpiGes e di confrontare i due risultati. In questo modo, si potranno risolvere eventuali ambiguità prima dell'introduzione produttiva della creazione dell'ITAR_K® tramite SpiGes nel 2026 (dati 2025).
 {{</collapsibleBlock>}}
+
+{{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -10,6 +10,7 @@ keywords: []
 {{<faqBlock>}}
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="ITARK">}}
 
+{{<numberedList>}}
 1. Nel quadro della SpiGes sono rilevate solo informazioni in merito ai casi di cure stazionarie. Come deve essere compilata la parte dell’ITAR_K® riservata alle cure ambulatoriali?
 {{<collapsibleBlock groupId="ITARK">}}
 L’ITAR_K® può essere creato con i dati SpiGes. I dati ambulatoriali sono rilevati nei tipi di UFI (unità finale d’imputazione) previsti a questo scopo (ad es., la tariffa di laboratorio).
@@ -45,5 +46,5 @@ Entro questa scadenza, i dati sui costi dovranno essere stati controllati automa
 {{<collapsibleBlock groupId="ITARK">}}
 Lo strumento centrale per la tariffazione e l'audit delle prestazioni sarà creato in futuro da SpiGes. Per garantire una transizione sicura e corretta, per la creazione di ITAR_K® è previsto il funzionamento parallelo della vecchia e della nuova piattaforma (rispettivamente H+ e SpiGes). Nel 2025 (dati 2024), l'ITAR_K® ufficiale continuerà a essere creato dalla piattaforma H+ come in precedenza. A partire da settembre 2025, tutti gli ospedali avranno anche la possibilità di creare l'ITAR_K® 2025 (dati 2024) tramite SpiGes e di confrontare i due risultati. In questo modo, si potranno risolvere eventuali ambiguità prima dell'introduzione produttiva della creazione dell'ITAR_K® tramite SpiGes nel 2026 (dati 2025).
 {{</collapsibleBlock>}}
-
+{{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -26,18 +26,14 @@ Entro questa scadenza, i dati sui costi dovranno essere stati controllati automa
 
 4. Non riusciamo a trovare una variabile SpiGes che permetta di trasferire i ricavi/costi della PEIG direttamente associati a un caso nella colonna PEIG prevista a questo scopo in ITAR_K®. Come viene calcolata la colonna PEIG di ITAR_K® con i dati SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li> Nella raffigurazione delle prestazioni d’interesse generale, fondamentalmente lo SpiGes si attiene alla giurisprudenza e alle raccomandazioni dell’associazione degli ospedali H+. REKOLE®® prevede la raffigurazione dei costi delle prestazioni d’interesse generale vincolate al caso e di quelle indipendenti dal caso. </li>
-<li> Da un punto di vista tecnico, è possibile discostarsi dai requisiti previsti da REKOLE®®. I costi e i ricavi della PEIG legata a un caso possono essere rilevati anche in un’unità di imputazione separata (tipo UFI 700-799). Anche questo è a discrezione del Cantone. In questo caso, è importante che i costi e i ricavi delle prestazioni AOMS siano registrati ugualmente con riferimento al caso (tipo UFI = 1). </li>
-</ul>
+- Nella raffigurazione delle prestazioni d’interesse generale, fondamentalmente lo SpiGes si attiene alla giurisprudenza e alle raccomandazioni dell’associazione degli ospedali H+. REKOLE®® prevede la raffigurazione dei costi delle prestazioni d’interesse generale vincolate al caso e di quelle indipendenti dal caso.
+- Da un punto di vista tecnico, è possibile discostarsi dai requisiti previsti da REKOLE®®. I costi e i ricavi della PEIG legata a un caso possono essere rilevati anche in un’unità di imputazione separata (tipo UFI 700-799). Anche questo è a discrezione del Cantone. In questo caso, è importante che i costi e i ricavi delle prestazioni AOMS siano registrati ugualmente con riferimento al caso (tipo UFI = 1).
 {{</collapsibleBlock>}}
 
 5. L'ITAR_K può essere completato sia a livello di azienda che di sito. Cosa è necessario fare in SpiGes? La decisione spetta ai Cantoni?
 {{<collapsibleBlock groupId="ITARK">}}
-<ul>
-<li> ITAR_K viene sempre compilato a livello di BUR-GESV; questo livello deve corrispondere all'indagine KS. Il Cantone fornisce all'UST le informazioni rilevanti per l'indagine sulla popolazione. In questo senso, il Cantone ha un'influenza. Tuttavia, deve collaborare con l'ospedale.  </li>
-<li> L'ITAR_K è lo strumento di base per le negoziazioni tra ospedali e assicurazioni. Il fatto che il Cantone abbia voce in capitolo sulla granularità dipende dal fatto che si tratti di un ospedale a lista, di un ospedale a contratto o di un ospedale in deroga. </li>
-</ul>
+- ITAR_K viene sempre compilato a livello di BUR-GESV; questo livello deve corrispondere all'indagine KS. Il Cantone fornisce all'UST le informazioni rilevanti per l'indagine sulla popolazione. In questo senso, il Cantone ha un'influenza. Tuttavia, deve collaborare con l'ospedale. 
+- L'ITAR_K è lo strumento di base per le negoziazioni tra ospedali e assicurazioni. Il fatto che il Cantone abbia voce in capitolo sulla granularità dipende dal fatto che si tratti di un ospedale a lista, di un ospedale a contratto o di un ospedale in deroga.
 {{</collapsibleBlock>}}
 
 6. Quando verrà generato l'ITAR_K® dalla piattaforma SpiGes?

--- a/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -11,40 +11,53 @@ keywords: []
 Aprire tutte le domande: {{<collapsibleGroupCommand groupId="ITARK">}}
 
 {{<numberedList>}}
-1. Nel quadro della SpiGes sono rilevate solo informazioni in merito ai casi di cure stazionarie. Come deve essere compilata la parte dell’ITAR_K® riservata alle cure ambulatoriali?
+{{<listItem>}}
+Nel quadro della SpiGes sono rilevate solo informazioni in merito ai casi di cure stazionarie. Come deve essere compilata la parte dell’ITAR_K® riservata alle cure ambulatoriali?
 {{<collapsibleBlock groupId="ITARK">}}
 L’ITAR_K® può essere creato con i dati SpiGes. I dati ambulatoriali sono rilevati nei tipi di UFI (unità finale d’imputazione) previsti a questo scopo (ad es., la tariffa di laboratorio).
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-2. Come viene creato l’ITAR_K® delle cliniche che costituiscono solo una parte di un’impresa ospedaliera? (ad es., la clinica St. Anne di Friburgo fa parte della Swiss Medical Network AG).
+{{<listItem>}}
+Come viene creato l’ITAR_K® delle cliniche che costituiscono solo una parte di un’impresa ospedaliera? (ad es., la clinica St. Anne di Friburgo fa parte della Swiss Medical Network AG).
 {{<collapsibleBlock groupId="ITARK">}}
 Sarà la clinica St. Anne di Friburgo a compilare la contabilità finanziaria (e tutti gli altri dati) per la statistica ospedaliera per ogni sua clinica (livello BURGESV). I costi di SpiGes possono essere aggregati in base a BURGESV.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-3. I dati sui costi devono essere inseriti entro il 31 marzo. È necessario fare una revisione di questi dati? Al momento non siamo in grado di eseguire una revisione, in quanto il bilancio annuale è sottoposto a revisione solo alla fine di marzo.
+{{<listItem>}}
+I dati sui costi devono essere inseriti entro il 31 marzo. È necessario fare una revisione di questi dati? Al momento non siamo in grado di eseguire una revisione, in quanto il bilancio annuale è sottoposto a revisione solo alla fine di marzo.
 {{<collapsibleBlock groupId="ITARK">}}
 Entro questa scadenza, i dati sui costi dovranno essere stati controllati automaticamente per la prima volta sulla piattaforma SpiGes. La revisione potrà avvenire in un secondo tempo.
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-4. Non riusciamo a trovare una variabile SpiGes che permetta di trasferire i ricavi/costi della PEIG direttamente associati a un caso nella colonna PEIG prevista a questo scopo in ITAR_K®. Come viene calcolata la colonna PEIG di ITAR_K® con i dati SpiGes?
+{{<listItem>}}
+Non riusciamo a trovare una variabile SpiGes che permetta di trasferire i ricavi/costi della PEIG direttamente associati a un caso nella colonna PEIG prevista a questo scopo in ITAR_K®. Come viene calcolata la colonna PEIG di ITAR_K® con i dati SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 - Nella raffigurazione delle prestazioni d’interesse generale, fondamentalmente lo SpiGes si attiene alla giurisprudenza e alle raccomandazioni dell’associazione degli ospedali H+. REKOLE®® prevede la raffigurazione dei costi delle prestazioni d’interesse generale vincolate al caso e di quelle indipendenti dal caso.
 - Da un punto di vista tecnico, è possibile discostarsi dai requisiti previsti da REKOLE®®. I costi e i ricavi della PEIG legata a un caso possono essere rilevati anche in un’unità di imputazione separata (tipo UFI 700-799). Anche questo è a discrezione del Cantone. In questo caso, è importante che i costi e i ricavi delle prestazioni AOMS siano registrati ugualmente con riferimento al caso (tipo UFI = 1).
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-5. L'ITAR_K può essere completato sia a livello di azienda che di sito. Cosa è necessario fare in SpiGes? La decisione spetta ai Cantoni?
+{{<listItem>}}
+L'ITAR_K può essere completato sia a livello di azienda che di sito. Cosa è necessario fare in SpiGes? La decisione spetta ai Cantoni?
 {{<collapsibleBlock groupId="ITARK">}}
 {{<markdown>}}
 - ITAR_K viene sempre compilato a livello di BUR-GESV; questo livello deve corrispondere all'indagine KS. Il Cantone fornisce all'UST le informazioni rilevanti per l'indagine sulla popolazione. In questo senso, il Cantone ha un'influenza. Tuttavia, deve collaborare con l'ospedale. 
 - L'ITAR_K è lo strumento di base per le negoziazioni tra ospedali e assicurazioni. Il fatto che il Cantone abbia voce in capitolo sulla granularità dipende dal fatto che si tratti di un ospedale a lista, di un ospedale a contratto o di un ospedale in deroga.
 {{</markdown>}}
 {{</collapsibleBlock>}}
+{{</listItem>}}
 
-6. Quando verrà generato l'ITAR_K® dalla piattaforma SpiGes?
+{{<listItem>}}
+Quando verrà generato l'ITAR_K® dalla piattaforma SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
 Lo strumento centrale per la tariffazione e l'audit delle prestazioni sarà creato in futuro da SpiGes. Per garantire una transizione sicura e corretta, per la creazione di ITAR_K® è previsto il funzionamento parallelo della vecchia e della nuova piattaforma (rispettivamente H+ e SpiGes). Nel 2025 (dati 2024), l'ITAR_K® ufficiale continuerà a essere creato dalla piattaforma H+ come in precedenza. A partire da settembre 2025, tutti gli ospedali avranno anche la possibilità di creare l'ITAR_K® 2025 (dati 2024) tramite SpiGes e di confrontare i due risultati. In questo modo, si potranno risolvere eventuali ambiguità prima dell'introduzione produttiva della creazione dell'ITAR_K® tramite SpiGes nel 2026 (dati 2025).
 {{</collapsibleBlock>}}
+{{</listItem>}}
+
 {{</numberedList>}}
 {{</faqBlock>}}

--- a/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
+++ b/content/it/FAQ/allgemeine_angaben/4_ITAR_K.md
@@ -27,14 +27,18 @@ Entro questa scadenza, i dati sui costi dovranno essere stati controllati automa
 
 4. Non riusciamo a trovare una variabile SpiGes che permetta di trasferire i ricavi/costi della PEIG direttamente associati a un caso nella colonna PEIG prevista a questo scopo in ITAR_K®. Come viene calcolata la colonna PEIG di ITAR_K® con i dati SpiGes?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 - Nella raffigurazione delle prestazioni d’interesse generale, fondamentalmente lo SpiGes si attiene alla giurisprudenza e alle raccomandazioni dell’associazione degli ospedali H+. REKOLE®® prevede la raffigurazione dei costi delle prestazioni d’interesse generale vincolate al caso e di quelle indipendenti dal caso.
 - Da un punto di vista tecnico, è possibile discostarsi dai requisiti previsti da REKOLE®®. I costi e i ricavi della PEIG legata a un caso possono essere rilevati anche in un’unità di imputazione separata (tipo UFI 700-799). Anche questo è a discrezione del Cantone. In questo caso, è importante che i costi e i ricavi delle prestazioni AOMS siano registrati ugualmente con riferimento al caso (tipo UFI = 1).
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 5. L'ITAR_K può essere completato sia a livello di azienda che di sito. Cosa è necessario fare in SpiGes? La decisione spetta ai Cantoni?
 {{<collapsibleBlock groupId="ITARK">}}
+{{<markdown>}}
 - ITAR_K viene sempre compilato a livello di BUR-GESV; questo livello deve corrispondere all'indagine KS. Il Cantone fornisce all'UST le informazioni rilevanti per l'indagine sulla popolazione. In questo senso, il Cantone ha un'influenza. Tuttavia, deve collaborare con l'ospedale. 
 - L'ITAR_K è lo strumento di base per le negoziazioni tra ospedali e assicurazioni. Il fatto che il Cantone abbia voce in capitolo sulla granularità dipende dal fatto che si tratti di un ospedale a lista, di un ospedale a contratto o di un ospedale in deroga.
+{{</markdown>}}
 {{</collapsibleBlock>}}
 
 6. Quando verrà generato l'ITAR_K® dalla piattaforma SpiGes?

--- a/content/it/eIAM_Onboarding/_index.md
+++ b/content/it/eIAM_Onboarding/_index.md
@@ -50,9 +50,9 @@ Per esempio:
 <!-- First column content goes here -->
 <p> 
 <ol>
-  <li> In questa colonna si vede l'EntID a livello di azienda e il numero Bur a livello di sito ospedaliero. </li>
-  <li> In questa colonna, si vede il cantone "amministrativo" dell'azienda/sito ospedaliero. </li>
-  <li> In questa colonna, si vede il cantone geografico dell'azienda/sito ospedaliero. </li>
+  - In questa colonna si vede l'EntID a livello di azienda e il numero Bur a livello di sito ospedaliero. 
+  - In questa colonna, si vede il cantone "amministrativo" dell'azienda/sito ospedaliero. 
+  - In questa colonna, si vede il cantone geografico dell'azienda/sito ospedaliero. 
 </ol> 
 </p>
 

--- a/content/it/eIAM_Onboarding/_index.md
+++ b/content/it/eIAM_Onboarding/_index.md
@@ -7,7 +7,7 @@ weight: 20
 type: docs
 ---
 
-In questo capitolo troverete tutti i passaggi da seguire per creare un profilo verificato che vi permetterà di connettervi alla piattaforma SpiGes. 
+In questo capitolo troverete tutti i passaggi da seguire per creare un profilo verificato che vi permetterà di connettervi alla piattaforma SpiGes.
 
 Per creare un CH-login con un secondo fattore forte e un'identità verificata per l'utilizzo della piattaforma SpiGes, sono necessari i seguenti passaggi:
 
@@ -22,7 +22,7 @@ Vi consigliamo di leggere queste pagine di istruzioni prima di provare a configu
 
 ## Come funziona eIAM
 
-eIAM è il sistema centrale di accesso e autorizzazione alle applicazioni web dell'Amministrazione federale. In parole povere, eIAM è l'infrastruttura di accesso centralizzata della Confederazione. Il suo scopo è quello di evitare la creazione di una procedura specifica per ogni applicazione. Questa centralizzazione consente di risparmiare denaro e di utilizzare gli stessi dati di accesso per tutte le applicazioni.    
+eIAM è il sistema centrale di accesso e autorizzazione alle applicazioni web dell'Amministrazione federale. In parole povere, eIAM è l'infrastruttura di accesso centralizzata della Confederazione. Il suo scopo è quello di evitare la creazione di una procedura specifica per ogni applicazione. Questa centralizzazione consente di risparmiare denaro e di utilizzare gli stessi dati di accesso per tutte le applicazioni.
 Ogni utente che accede all'applicazione SpiGes viene automaticamente reindirizzato al portale eIAM per la procedura di autenticazione. Il sistema chiederà quindi all'utente di convalidare la connessione sul proprio telefono cellulare per verificare che si tratti effettivamente della persona giusta che sta cercando di connettersi.  
 
 {{<alert color="warning">}}
@@ -30,7 +30,8 @@ Poiché l'identità dell'utente deve essere verificata, gli account dell'applica
 {{</alert>}}
 
 ## Struttura delle unità eIAM
-I diversi utenti della piattaforma SpiGes sono organizzati come segue: 
+
+I diversi utenti della piattaforma SpiGes sono organizzati come segue:
 
 - Cantone
     - Aziende
@@ -48,13 +49,19 @@ Per esempio:
 
 <div class="left_col">
 <!-- First column content goes here -->
-<p> 
-<ol>
-  - In questa colonna si vede l'EntID a livello di azienda e il numero Bur a livello di sito ospedaliero. 
-  - In questa colonna, si vede il cantone "amministrativo" dell'azienda/sito ospedaliero. 
-  - In questa colonna, si vede il cantone geografico dell'azienda/sito ospedaliero. 
-</ol> 
-</p>
+{{<numberedList>}}
+{{<listItem>}}
+In questa colonna si vede l'EntID a livello di azienda e il numero Bur a livello di sito ospedaliero.
+{{</listItem>}}
+
+{{<listItem>}}
+In questa colonna, si vede il cantone "amministrativo" dell'azienda/sito ospedaliero.
+{{</listItem>}}
+
+{{<listItem>}}
+In questa colonna, si vede il cantone geografico dell'azienda/sito ospedaliero.
+{{</listItem>}}
+{{</numberedList>}}
 
 <p> Si può notare che il cantone amministrativo e il cantone geografico del sito 1 non sono gli stessi.  </p>
 </div>

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -11,9 +11,9 @@ other = "SpiGes"
 [project_link]
 other = "https://www.spiges.admin.ch"
 [collapsible_block_click_to_expand_click_text]
-other = "Klicken Sie hier, um zu erweitern..."
+other = "Antwort"
 [collapsible_block_click_to_collapse_click_text]
-other = "Klicken Sie hier, um zu reduzieren..."
+other = "Antwort"
 [collapsible_group_command_expand_all_click_text]
 other = "Alle erweitern"
 [collapsible_group_command_collapse_all_click_text]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -11,13 +11,13 @@ other = "SpiGes"
 [project_link]
 other = "https://www.spiges.admin.ch"
 [collapsible_block_click_to_expand_click_text]
-other = "Cliquez ici pour développer..."
+other = "Réponse"
 [collapsible_block_click_to_collapse_click_text]
-other = "Cliquez ici pour réduire..."
+other = "Réponse"
 [collapsible_group_command_expand_all_click_text]
-other = "Développer tout"
+other = "Tout ouvrir"
 [collapsible_group_command_collapse_all_click_text]
-other = "Réduire tout"
+other = "Tout fermer"
 [collapsible_block_click_to_expand_collapse_tooltip_text]
 other = "Cliquez ici pour développer/réduire"
 [collapsible_group_command_click_to_expand_collapse_all_tooltip_text]

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -11,9 +11,9 @@ other = "SpiGes"
 [project_link]
 other = "https://www.spiges.admin.ch"
 [collapsible_block_click_to_expand_click_text]
-other = "Clicca qui per espandere..."
+other = "Risposta"
 [collapsible_block_click_to_collapse_click_text]
-other = "Clicca qui per comprimere..."
+other = "Risposta"
 [collapsible_group_command_expand_all_click_text]
 other = "Espandere tutto"
 [collapsible_group_command_collapse_all_click_text]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,30 +1,28 @@
 <footer>
   <div class="footer-item footer-item-info">
-    &copy; {{ now.Year }} {{ T "copyright" }} |
+    &copy; {{ now.Year }} {{ T "copyright" }} | 
     v{{ .Site.Params.version }}
     (
     {{ if (and (isset .Site.Params "githash") (not (eq .Site.Params.gitHash ""))) }}
-    {{ .Site.Params.gitHash }},
+    {{ .Site.Params.gitHash }}, 
     {{ end }}
 
     {{ if (and (isset .Site.Params "builddatetime") (not (eq .Site.Params.buildDatetime ""))) }}
     {{ .Site.Params.buildDatetime }}
     {{ else }}
     {{ $t := time.Now }}
-    {{ $t | time.Format ":date_medium" }} {{ $t | time.Format ":time_medium" }}
+    {{ $t  | time.Format ":date_medium" }} {{ $t  | time.Format ":time_medium" }}
     {{ end }}
     )
   </div>
   <ul class="footer-item footer-item-links">
-    -
-    <a href="{{ T " legal_link" }}" target="_blank" style="margin-right: 1em;">{{ T "legal_text" }}</a>
-
-    -
-    <a href="{{ T " legal_link" }}" title="legal-link-logo">
-      <img decoding="async" loading="lazy"
-        src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-nd.png" width="118" height="41"
-        align="right" alt="legal-link-logo" />
-    </a>
-
-
+    <li>
+      <a href="{{ T "legal_link" }}" target="_blank" style="margin-right: 1em;">{{ T "legal_text" }}</a>
+    </li>
+    <li>
+      <a href="{{ T "legal_link" }}" title="legal-link-logo">
+        <img decoding="async" loading="lazy" src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-nd.png" width="118" height="41" align="right" alt="legal-link-logo" />
+      </a>
+    </li>
+  </ul>
 </footer>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,28 +1,30 @@
 <footer>
   <div class="footer-item footer-item-info">
-    &copy; {{ now.Year }} {{ T "copyright" }} | 
+    &copy; {{ now.Year }} {{ T "copyright" }} |
     v{{ .Site.Params.version }}
     (
     {{ if (and (isset .Site.Params "githash") (not (eq .Site.Params.gitHash ""))) }}
-    {{ .Site.Params.gitHash }}, 
+    {{ .Site.Params.gitHash }},
     {{ end }}
 
     {{ if (and (isset .Site.Params "builddatetime") (not (eq .Site.Params.buildDatetime ""))) }}
     {{ .Site.Params.buildDatetime }}
     {{ else }}
     {{ $t := time.Now }}
-    {{ $t  | time.Format ":date_medium" }} {{ $t  | time.Format ":time_medium" }}
+    {{ $t | time.Format ":date_medium" }} {{ $t | time.Format ":time_medium" }}
     {{ end }}
     )
   </div>
   <ul class="footer-item footer-item-links">
-    <li>
-      <a href="{{ T "legal_link" }}" target="_blank" style="margin-right: 1em;">{{ T "legal_text" }}</a>
-    </li>
-    <li>
-      <a href="{{ T "legal_link" }}" title="legal-link-logo">
-        <img decoding="async" loading="lazy" src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-nd.png" width="118" height="41" align="right" alt="legal-link-logo" />
-      </a>
-    </li>
-  </ul>
+    -
+    <a href="{{ T " legal_link" }}" target="_blank" style="margin-right: 1em;">{{ T "legal_text" }}</a>
+
+    -
+    <a href="{{ T " legal_link" }}" title="legal-link-logo">
+      <img decoding="async" loading="lazy"
+        src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-nd.png" width="118" height="41"
+        align="right" alt="legal-link-logo" />
+    </a>
+
+
 </footer>

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,30 +1,28 @@
 <ul class="language-switcher">
     {{ $currentPage := .Page }}
     {{ range $.Site.Languages }}
-        <li>
-			{{ $langCode := .Lang }}
-            {{ $translatedPage := $currentPage }}
-            {{ $translationExists := false }}
-            <!-- Loop through available translations to find the corresponding one -->
-            {{ range $currentPage.AllTranslations }}
-                {{ if eq .Lang $langCode }}
-                    {{ $translatedPage = . }}
-                    {{ $translationExists = true }}
-                    <!-- Break once a matching translation is found -->
-                    {{ break }}
-                {{ end }}
-            {{ end }}
-            <!-- Generate the link based on translation availability -->
-            {{ if $translationExists }}
-                {{ if eq $currentPage.Lang $langCode }}
-                    <a class="active" href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
-                {{ else }}
-                    <a href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
-                {{ end }}
-            {{ else }}
-                <a class="disabled" href="javascript:void(0);">{{ upper $langCode }}</a>
-            {{ end }}
-        </li>
-    {{- end }}
-</ul>
+    -
+    {{ $langCode := .Lang }}
+    {{ $translatedPage := $currentPage }}
+    {{ $translationExists := false }}
+    <!-- Loop through available translations to find the corresponding one -->
+    {{ range $currentPage.AllTranslations }}
+    {{ if eq .Lang $langCode }}
+    {{ $translatedPage = . }}
+    {{ $translationExists = true }}
+    <!-- Break once a matching translation is found -->
+    {{ break }}
+    {{ end }}
+    {{ end }}
+    <!-- Generate the link based on translation availability -->
+    {{ if $translationExists }}
+    {{ if eq $currentPage.Lang $langCode }}
+    <a class="active" href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
+    {{ else }}
+    <a href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
+    {{ end }}
+    {{ else }}
+    <a class="disabled" href="javascript:void(0);">{{ upper $langCode }}</a>
+    {{ end }}
 
+    {{- end }}

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,28 +1,30 @@
 <ul class="language-switcher">
     {{ $currentPage := .Page }}
     {{ range $.Site.Languages }}
-    -
-    {{ $langCode := .Lang }}
-    {{ $translatedPage := $currentPage }}
-    {{ $translationExists := false }}
-    <!-- Loop through available translations to find the corresponding one -->
-    {{ range $currentPage.AllTranslations }}
-    {{ if eq .Lang $langCode }}
-    {{ $translatedPage = . }}
-    {{ $translationExists = true }}
-    <!-- Break once a matching translation is found -->
-    {{ break }}
-    {{ end }}
-    {{ end }}
-    <!-- Generate the link based on translation availability -->
-    {{ if $translationExists }}
-    {{ if eq $currentPage.Lang $langCode }}
-    <a class="active" href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
-    {{ else }}
-    <a href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
-    {{ end }}
-    {{ else }}
-    <a class="disabled" href="javascript:void(0);">{{ upper $langCode }}</a>
-    {{ end }}
-
+        <li>
+			{{ $langCode := .Lang }}
+            {{ $translatedPage := $currentPage }}
+            {{ $translationExists := false }}
+            <!-- Loop through available translations to find the corresponding one -->
+            {{ range $currentPage.AllTranslations }}
+                {{ if eq .Lang $langCode }}
+                    {{ $translatedPage = . }}
+                    {{ $translationExists = true }}
+                    <!-- Break once a matching translation is found -->
+                    {{ break }}
+                {{ end }}
+            {{ end }}
+            <!-- Generate the link based on translation availability -->
+            {{ if $translationExists }}
+                {{ if eq $currentPage.Lang $langCode }}
+                    <a class="active" href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
+                {{ else }}
+                    <a href="{{ $translatedPage.RelPermalink }}">{{ upper $langCode }}</a>
+                {{ end }}
+            {{ else }}
+                <a class="disabled" href="javascript:void(0);">{{ upper $langCode }}</a>
+            {{ end }}
+        </li>
     {{- end }}
+</ul>
+

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 {{ $cover := and
-    (.HasShortcode "blocks/cover")
-    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
+(.HasShortcode "blocks/cover")
+(not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
 <div class="header-wrapper">
@@ -10,9 +10,9 @@
         {{- /**/ -}}
         <span class="navbar-brand__logo navbar-logo">
           {{- if ne .Site.Params.ui.navbar_logo false -}}
-            {{ with resources.Get "icons/logo.svg" -}}
-              {{ ( . | minify).Content | safeHTML -}}
-            {{ end -}}
+          {{ with resources.Get "icons/logo.svg" -}}
+          {{ ( . | minify).Content | safeHTML -}}
+          {{ end -}}
           {{ end -}}
         </span>
       </a>
@@ -31,9 +31,9 @@
 </div>
 <div class="layout-navigation">
   <nav>
-    <ul>
-      <li><a class="active" href="{{ .Site.Home.RelPermalink }}">{{ T "home_text" }}</a></li>
-      <li><a href="{{ T "project_link" }}" target="_blank">{{ T "project_text" }}</a></li>
-    </ul>
+
+    -<a class="active" href="{{ .Site.Home.RelPermalink }}">{{ T "home_text" }}</a>
+    -<a href="{{ T " project_link" }}" target="_blank">{{ T "project_text" }}</a>
+
   </nav>
 </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 {{ $cover := and
-(.HasShortcode "blocks/cover")
-(not .Site.Params.ui.navbar_translucent_over_cover_disable)
+    (.HasShortcode "blocks/cover")
+    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
 <div class="header-wrapper">
@@ -10,9 +10,9 @@
         {{- /**/ -}}
         <span class="navbar-brand__logo navbar-logo">
           {{- if ne .Site.Params.ui.navbar_logo false -}}
-          {{ with resources.Get "icons/logo.svg" -}}
-          {{ ( . | minify).Content | safeHTML -}}
-          {{ end -}}
+            {{ with resources.Get "icons/logo.svg" -}}
+              {{ ( . | minify).Content | safeHTML -}}
+            {{ end -}}
           {{ end -}}
         </span>
       </a>
@@ -31,9 +31,9 @@
 </div>
 <div class="layout-navigation">
   <nav>
-
-    -<a class="active" href="{{ .Site.Home.RelPermalink }}">{{ T "home_text" }}</a>
-    -<a href="{{ T " project_link" }}" target="_blank">{{ T "project_text" }}</a>
-
+    <ul>
+      <li><a class="active" href="{{ .Site.Home.RelPermalink }}">{{ T "home_text" }}</a></li>
+      <li><a href="{{ T "project_link" }}" target="_blank">{{ T "project_text" }}</a></li>
+    </ul>
   </nav>
 </div>

--- a/layouts/shortcodes/table_of_contents.html
+++ b/layouts/shortcodes/table_of_contents.html
@@ -1,4 +1,3 @@
 <div class="toc">
-  {{ .Page.TableOfContents | replaceRE "[[:space:]]*-[[:space:]]*" "" | replaceRE "[[:space:]]*[[:space:]]*" ""
-  | safeHTML }}
+  {{ .Page.TableOfContents | replaceRE "<ul>[[:space:]]*<li>[[:space:]]*<ul>" "<ul>" | replaceRE "</ul>[[:space:]]*</li>[[:space:]]*</ul>" "</ul>" |  safeHTML }}
 </div>

--- a/layouts/shortcodes/table_of_contents.html
+++ b/layouts/shortcodes/table_of_contents.html
@@ -1,3 +1,4 @@
 <div class="toc">
-  {{ .Page.TableOfContents | replaceRE "<ul>[[:space:]]*<li>[[:space:]]*<ul>" "<ul>" | replaceRE "</ul>[[:space:]]*</li>[[:space:]]*</ul>" "</ul>" |  safeHTML }}
+  {{ .Page.TableOfContents | replaceRE "[[:space:]]*-[[:space:]]*" "" | replaceRE "[[:space:]]*[[:space:]]*" ""
+  | safeHTML }}
 </div>


### PR DESCRIPTION
FAQ pages updated:
- `numberedList` and `listItem` shortcodes used instead of HTML elements
- `markdown` shortcode used to be able to use markdown code inside a shortcode
- `faqBlock` shortcode used