### PR TITLE
[#81] - New shortcodes `link` and `lineBreak` added

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,23 +4,27 @@
         "indent": 4
     },
     "MD010": false,
-    "MD013": { 
+    "MD013": {
         "stern": true,
         "line_length": 99999,
         "code_block_line_length": 80,
         "heading_line_length": 120
     },
-    "MD024": { "siblings_only": true },
+    "MD024": {
+        "siblings_only": true
+    },
     "MD033": {
         "allowed_elements": [
-            "collapsibleGroupCommand", 
-            "collapsibleBlock", 
-            "insertImage", 
-            "alert", 
-            "numberedList", 
-            "listItem", 
+            "collapsibleGroupCommand",
+            "collapsibleBlock",
+            "insertImage",
+            "alert",
+            "numberedList",
+            "listItem",
             "faqBlock",
-            "markdown"
+            "markdown",
+            "link",
+            "lineBreak"
         ]
     }
 }

--- a/layouts/shortcodes/lineBreak.html
+++ b/layouts/shortcodes/lineBreak.html
@@ -1,0 +1,5 @@
+{{/* Shortcode "lineBreak" to return to new line.
+  This shortcode is especially useful for returning to a new line after a shortcode.
+*/}}
+
+<br />

--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -1,0 +1,22 @@
+{{/* Shortcode "link" to manage properly the link usage.
+  Parameters:
+  - url: URL of the link
+  - newTab: Boolean indicating whether the link must open a new tab.
+*/}}
+
+{{ $url := .Get "url" }}
+{{ $newTab := .Get "newTab" | default "false" }}
+
+{{ if strings.HasPrefix $url "/" }}
+  {{ $url = printf "%s%s%s"
+    (.Site.BaseURL | replaceRE "/+$" "") .Site.LanguagePrefix $url
+  }}
+{{ end }}
+
+
+<a
+  href="{{ $url }}"
+  {{ if eq $newTab "true" }}target="_blank" rel="noopener noreferrer"{{ end }}
+>
+  {{ .Inner }}
+</a>


### PR DESCRIPTION
- New shortcodes `link` and `lineBreak` added
- The `link` shortcode allows opening internal and external pages.
- The `lineBreak` shortcode allows applying properly newline after shortcodes which follow each other.