### PR TITLE
[#64] - New shortcodes/partials added allowing to create grid layouts

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -24,7 +24,10 @@
             "faqBlock",
             "markdown",
             "link",
-            "lineBreak"
+            "lineBreak",
+            "grid",
+            "row",
+            "column"
         ]
     }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -53,6 +53,7 @@
         "scss/selector-no-redundant-nesting-selector": true,
         "scss/at-import-no-partial-leading-underscore": true,
         "scss/operator-no-unspaced": true,
+        "scss/at-mixin-argumentless-call-parentheses": "always",
         "color-hex-length": "long",
         "number-max-precision": [
             3,

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,6 +1,7 @@
 @import "utilities/index";
 @import "abstracts/index";
 @import "shortcodes/index";
+@import "partials/index";
 
 html {
   line-height: 1.5;

--- a/assets/scss/partials/_index.scss
+++ b/assets/scss/partials/_index.scss
@@ -1,0 +1,1 @@
+@import "layouts/index";

--- a/assets/scss/partials/layouts/_column.scss
+++ b/assets/scss/partials/layouts/_column.scss
@@ -1,0 +1,3 @@
+.column-layout{
+    visibility: visible;
+}

--- a/assets/scss/partials/layouts/_grid.scss
+++ b/assets/scss/partials/layouts/_grid.scss
@@ -1,0 +1,3 @@
+.grid-layout{
+    visibility: visible;
+}

--- a/assets/scss/partials/layouts/_index.scss
+++ b/assets/scss/partials/layouts/_index.scss
@@ -1,0 +1,3 @@
+@import "grid";
+@import "row";
+@import "column";

--- a/assets/scss/partials/layouts/_row.scss
+++ b/assets/scss/partials/layouts/_row.scss
@@ -1,0 +1,3 @@
+.row-layout{
+    visibility: visible;
+}

--- a/layouts/partials/layouts/column.html
+++ b/layouts/partials/layouts/column.html
@@ -1,0 +1,60 @@
+{{- $classes := slice -}}
+
+{{- if .width -}}
+  {{- if eq .width "auto" -}}
+    {{ $classes = $classes | append (print "col-" .width) }}
+  {{- else -}}
+    {{- $base := (div (mul (int .width) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-" $base) }}
+  {{- end -}}
+{{- else -}}
+  {{ $classes = $classes | append (print "col") }}
+{{- end -}}
+{{- if .smWidth -}}
+  {{- if eq .smWidth "auto" -}}
+    {{ $classes = $classes | append (print "col-sm-" .smWidth) }}
+  {{- else -}}
+    {{- $sm := (div (mul (int .smWidth) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-sm-" $sm) }}
+  {{- end -}}
+{{- end -}}
+{{- if .mdWidth -}}
+  {{- if eq .mdWidth "auto" -}}
+    {{ $classes = $classes | append (print "col-md-" .mdWidth) }}
+  {{- else -}}
+    {{- $md := (div (mul (int .mdWidth) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-md-" $md) }}
+  {{- end -}}
+{{- end -}}
+{{- if .lgWidth -}}
+  {{- if eq .lgWidth "auto" -}}
+    {{ $classes = $classes | append (print "col-lg-" .lgWidth) }}
+  {{- else -}}
+    {{- $lg := (div (mul (int .lgWidth) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-lg-" $lg) }}
+  {{- end -}}
+{{- end -}}
+{{- if .xlWidth -}}
+  {{- if eq .xlWidth "auto" -}}
+    {{ $classes = $classes | append (print "col-xl-" .xlWidth) }}
+  {{- else -}}
+    {{- $xl := (div (mul (int .xlWidth) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-xl-" $xl) }}
+  {{- end -}}
+
+{{- end -}}
+{{- if .xxlWidth -}}
+  {{- if eq .xxlWidth "auto" -}}
+    {{ $classes = $classes | append (print "col-xxl-" .xxlWidth) }}
+  {{- else -}}
+    {{- $xxl := (div (mul (int .xxlWidth) 12) 100) | math.Round -}}
+    {{ $classes = $classes | append (print "col-xxl-" $xxl) }}
+  {{- end -}}
+{{- end -}}
+
+{{- $classString := delimit $classes " " -}}
+
+
+<div class="{{ $classString }} column-layout {{ .class }}">
+  {{ .content }}
+</div>

--- a/layouts/partials/layouts/grid.html
+++ b/layouts/partials/layouts/grid.html
@@ -1,0 +1,3 @@
+<div class="container grid-layout {{ .class }}">
+  {{ .content }}
+</div>

--- a/layouts/partials/layouts/row.html
+++ b/layouts/partials/layouts/row.html
@@ -1,0 +1,54 @@
+{{- $classes := slice -}}
+
+{{- if .justify -}}
+  {{ $classes = $classes | append (print "justify-content-" .justify) }}
+{{- end -}}
+
+{{- if .smJustify -}}
+  {{ $classes = $classes | append (print "justify-content-sm-" .smJustify) }}
+{{- end -}}
+
+{{- if .mdJustify -}}
+  {{ $classes = $classes | append (print "justify-content-md-" .mdJustify) }}
+{{- end -}}
+
+{{- if .lgJustify -}}
+  {{ $classes = $classes | append (print "justify-content-lg-" .lgJustify) }}
+{{- end -}}
+
+{{- if .xlJustify -}}
+  {{ $classes = $classes | append (print "justify-content-xl-" .xlJustify) }}
+{{- end -}}
+
+{{- if .xxlJustify -}}
+  {{ $classes = $classes | append (print "justify-content-xxl-" .xxlJustify) }}
+{{- end -}}
+
+{{- if .align -}}
+  {{ $classes = $classes | append (print "align-items-" .align) }}
+{{- end -}}
+
+{{- if .smAlign -}}
+  {{ $classes = $classes | append (print "align-items-sm-" .smAlign) }}
+{{- end -}}
+
+{{- if .mdAlign -}}
+  {{ $classes = $classes | append (print "align-items-md-" .mdAlign) }}
+{{- end -}}
+
+{{- if .lgAlign -}}
+  {{ $classes = $classes | append (print "align-items-lg-" .lgAlign) }}
+{{- end -}}
+
+{{- if .xlAlign -}}
+  {{ $classes = $classes | append (print "align-items-xl-" .xlAlign) }}
+{{- end -}}
+
+{{- if .xxlAlign -}}
+  {{ $classes = $classes | append (print "align-items-xxl-" .xxlAlign) }}
+{{- end -}}
+
+{{- $classString := delimit $classes " " -}}
+<div class="row row-layout {{ $classString }} {{ .class }}">
+  {{ .content }}
+</div>

--- a/layouts/shortcodes/layouts/column.html
+++ b/layouts/shortcodes/layouts/column.html
@@ -1,0 +1,19 @@
+{{ $class := .Get "class" | default "" }}
+{{- $width := .Get "width" | default "" -}}
+{{- $smWidth := .Get "smWidth" | default "" -}}
+{{- $mdWidth := .Get "mdWidth" | default "" -}}
+{{- $lgWidth := .Get "lgWidth" | default "" -}}
+{{- $xlWidth := .Get "xlWidth" | default "" -}}
+{{- $xxlWidth := .Get "xxlWidth" | default "" -}}
+
+{{ partial "layouts/column.html" (dict
+  "content" .Inner
+  "width" $width
+  "smWidth" $smWidth
+  "mdWidth" $mdWidth
+  "lgWidth" $lgWidth
+  "xlWidth" $xlWidth
+  "xxlWidth" $xxlWidth
+  "class" $class
+  )
+}}

--- a/layouts/shortcodes/layouts/column.html
+++ b/layouts/shortcodes/layouts/column.html
@@ -1,3 +1,42 @@
+{{/* Shortcode for creating a `column` inside a `row`.
+
+  This shortcode uses the partial `column` to create a column layout.
+  See https://getbootstrap.com/docs/5.0/layout/grid/.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the row element.
+  This parameter is optional and defaults to an empty string if not provided.
+  - width: Value in % representing the space occupied by the column.
+  - smWidth: Same as width, from >= 576px.
+  - mdWidth: Same as width, From >= 768px.
+  - lgWidth: Same as width, From >= 992px.
+  - xlWidth: Same as width, From >= 1200px.
+  - xxlWidth: Same as width, From >= 1400px.
+
+  Example:
+  {{< layouts/grid
+>}}
+{{< layouts/row justify="center" align="center" >}}
+
+{{< layouts/column width="40" >}}
+{{< markdown >}}
+Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore,
+cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod
+maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor
+repellendus.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< layouts/column width="60" >}}
+{{< markdown >}}
+Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus
+saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< /layouts/row >}}
+{{< /layouts/grid >}}
+*/}}
 {{ $class := .Get "class" | default "" }}
 {{- $width := .Get "width" | default "" -}}
 {{- $smWidth := .Get "smWidth" | default "" -}}

--- a/layouts/shortcodes/layouts/grid.html
+++ b/layouts/shortcodes/layouts/grid.html
@@ -1,3 +1,36 @@
+{{/* Shortcode for creating a `grid` layout.
+
+  This shortcode uses the partial `grid` to create a grid layout.
+  See https://getbootstrap.com/docs/5.0/layout/grid/.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the grid element.
+  This parameter is optional and defaults to an empty string if not provided.
+
+  Example:
+  {{<layouts/grid
+>}}
+{{< layouts/row >}}
+
+{{< layouts/column width="40" >}}
+{{< markdown >}}
+Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore,
+cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod
+maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor
+repellendus.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< layouts/column width="60" >}}
+{{< markdown >}}
+Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus
+saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< /layouts/row >}}
+{{< /layouts/grid >}}
+*/}}
 {{ $class := .Get "class" | default "" }}
 {{ $content := .Inner }}
 {{ partial "layouts/grid.html" (dict "content" $content "class" $class) }}

--- a/layouts/shortcodes/layouts/grid.html
+++ b/layouts/shortcodes/layouts/grid.html
@@ -1,0 +1,3 @@
+{{ $class := .Get "class" | default "" }}
+{{ $content := .Inner }}
+{{ partial "layouts/grid.html" (dict "content" $content "class" $class) }}

--- a/layouts/shortcodes/layouts/row.html
+++ b/layouts/shortcodes/layouts/row.html
@@ -1,3 +1,48 @@
+{{/* Shortcode for creating a `row` layout inside a `grid` layout.
+
+  This shortcode uses the partial `row` to create a row layout.
+  See https://getbootstrap.com/docs/5.0/layout/grid/.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the row element.
+  This parameter is optional and defaults to an empty string if not provided.
+  - justify: Allows changing the alignment of the columns horizontally. See https://getbootstrap.com/docs/5.0/utilities/flex/#justify-content
+  - smJustify: Same as justify, from >= 576px.
+  - mdJustify: Same as justify, from >= 768px.
+  - lgJustify: Same as justify, from >= 992px.
+  - xlJustify: Same as justify, from >= 1200px.
+  - xxlJustify: Same as justify, from >= 1400px.
+  - align: Allows changing the alignment of the columns vertically. See https://getbootstrap.com/docs/5.0/utilities/flex/#align-items
+  - smAlign: Same as align, from >= 576px.
+  - mdAlign: Same as align, from >= 768px.
+  - lgAlign: Same as align, from >= 992px.
+  - xlAlign: Same as align, from >= 1200px.
+  - xxlAlign: Same as align, from >= 1400px.
+
+  Example:
+  {{< layouts/grid
+>}}
+{{< layouts/row justify="center" align="center" >}}
+
+{{< layouts/column width="40" >}}
+{{< markdown >}}
+Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore,
+cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod
+maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor
+repellendus.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< layouts/column width="60" >}}
+{{< markdown >}}
+Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus
+saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.
+{{< /markdown >}}
+{{< layouts/column >}}
+
+{{< /layouts/row >}}
+{{< /layouts/grid >}}
+*/}}
 {{ $class := .Get "class" | default "" }}
 {{- $justify := .Get "justify" | default "" -}}
 {{- $smJustify := .Get "smJustify" | default "" -}}

--- a/layouts/shortcodes/layouts/row.html
+++ b/layouts/shortcodes/layouts/row.html
@@ -1,0 +1,31 @@
+{{ $class := .Get "class" | default "" }}
+{{- $justify := .Get "justify" | default "" -}}
+{{- $smJustify := .Get "smJustify" | default "" -}}
+{{- $mdJustify := .Get "mdJustify" | default "" -}}
+{{- $lgJustify := .Get "lgJustify" | default "" -}}
+{{- $xlJustify := .Get "xlJustify" | default "" -}}
+{{- $xxlJustify := .Get "xxlJustify" | default "" -}}
+{{- $align := .Get "align" | default "" -}}
+{{- $smAlign := .Get "smAlign" | default "" -}}
+{{- $mdAlign := .Get "mdAlign" | default "" -}}
+{{- $lgAlign := .Get "lgAlign" | default "" -}}
+{{- $xlAlign := .Get "xlAlign" | default "" -}}
+{{- $xxlAlign := .Get "xxlAlign" | default "" -}}
+
+{{ $content := .Inner }}
+{{ partial "layouts/row.html" (dict
+  "content" $content
+  "justify" $justify
+  "smJustify" $smJustify
+  "mdJustify" $mdJustify
+  "lgJustify" $lgJustify
+  "xlJustify" $xlJustify
+  "xxlJustify" $xxlJustify
+  "align" $align
+  "smAlign" $smAlign
+  "mdAlign" $mdAlign
+  "lgAlign" $lgAlign
+  "xlAlign" $xlAlign
+  "xxlAlign" $xxlAlign
+  "class" $class)
+}}


### PR DESCRIPTION
- New partials `Grid`, `Row` and `Column` added, allowing reusability inside other templates
- New shortcodes `Grid`, `Row` and `Column` added, using the new partials