### PR TITLE
Rc 150 new shortcode unordered list

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,6 +20,7 @@
             "insertImage",
             "alert",
             "numberedList",
+            "unorderedList",
             "listItem",
             "faqBlock",
             "markdown",

--- a/assets/scss/shortcodes/_unordered-list.scss
+++ b/assets/scss/shortcodes/_unordered-list.scss
@@ -1,0 +1,3 @@
+.unordered-list {
+  visibility: visible;
+}

--- a/content/de/FAQ/Falldaten/1_administratives.md
+++ b/content/de/FAQ/Falldaten/1_administratives.md
@@ -22,6 +22,7 @@ Die Fallzusammenführung wird in SpiGes gemäss den Richtlinien der SwissDRG AG 
 fall_id_ch: Wer generiert diese Fallnummer und wird diese automatisch in Opale (IRP-System) hinterlegt? Bisher konnten wir die Fallidentifikation in beiden Dateien (BFS-Daten und Fallkostendatei) automatisch in Opale generieren.
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
+
 - Die schweizweit eindeutige Fallnummer wird durch die SpiGes-Plattform generiert. Bei einem Datenexport aus der Plattform steht diese fall_id_ch den Datennutzern zur Verfügung.
 - Der Identifikator des Falls, die Variable fall_id wird durch die Spitäler generiert. Die Spitalsoftware (wie z.B. Opale) sollte weiterhin über diese Funktion verfügen.
 {{</markdown>}}
@@ -39,8 +40,9 @@ Tatsächlich sind die Definitionen in diesem Aspekt vielleicht noch nicht für a
 Wie ist der «interne Übertritt» definiert?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
--	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv)
--	oder für die sogenannten Wartepatienten/-patientinnen
+
+-	Übertritt von einem Bereich (Akut, Psychiatrie, Rehabilitation) in einen anderen Bereich desselben Spitals (burnr_gesv),
+-	oder für die sogenannten Wartepatienten/-patientinnen.
 {{</markdown>}}
 {{</collapsibleBlock>}}
 {{</listItem>}}
@@ -55,13 +57,28 @@ Rückführung eines Patienten oder einer Patientin mit Schweizer Hauptwohnsitz a
 {{<listItem>}}
 Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 24 Std.» und «6 = Rückverlegung» der Variable Eintrittsart)
 {{<collapsibleBlock groupId="admninistratives">}}
-{{<markdown>}}
 
--	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: [https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf](https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf)
--	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital.
--	Gemäss SwissDRG AG wird Rückverlegung nur genutzt als Eintrittsart, wenn der Patient >18 Tage in einem anderen Spital war und wieder zurückkommt und somit ein neuer Fall eröffnet wird.
--	Ein Patient, der nach <18 Tage ins Spital zurückkommt, erhält die Eintrittsart-Angabe seines 1. Eintritts, weil er ja zusammengelegt wird.
-{{</markdown>}}
+{{<unorderedList>}}
+
+{{<listItem>}}
+Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden:  
+{{<link url="https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf" newTab="true">}}Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf{{</link>}}
+{{</listItem>}}
+
+{{<listItem>}}
+Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital.
+{{</listItem>}}
+
+{{<listItem>}}
+Gemäss SwissDRG AG wird Rückverlegung nur genutzt als Eintrittsart, wenn der Patient >18 Tage in einem anderen Spital war und wieder zurückkommt und somit ein neuer Fall eröffnet wird.
+{{</listItem>}}
+
+{{<listItem>}}
+Ein Patient, der nach <18 Tage ins Spital zurückkommt, erhält die Eintrittsart-Angabe seines 1. Eintritts, weil er ja zusammengelegt wird.
+{{</listItem>}}
+
+{{</unorderedList>}}
+
 {{</collapsibleBlock>}}
 {{</listItem>}}
 
@@ -69,8 +86,8 @@ Wie ist eine «Verlegung» definiert? (z.B. die Codes «5 = Verlegung innerhalb 
 Wie werden Fälle, die von der Rehabilitation (Tarif ST-REHA) in die Langzeitpflege (Tarif «Pflegetaxe») des gleichen Betriebs übergehen codiert? Die Variablen 1.2.V02 und 1.5.V03 erlauben uns nicht, «Langzeitpflege, gleicher Betrieb» anzugeben.
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
-Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden:        
-austritt_aufenthalt: 2 = Krankenheim, Pflegeheim        
+Dies war bereits bei der MS so; der Fall wechselt von Rehabilitation zu SOMED (gleicher Betrieb); bei Code 2 sind beide Möglichkeiten enthalten (gleicher Betrieb oder anderer Betrieb). Der Fall muss wie folgt kodiert werden:
+austritt_aufenthalt: 2 = Krankenheim, Pflegeheim
 eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb
 {{</markdown>}}
 {{</collapsibleBlock>}}
@@ -82,6 +99,7 @@ eintritt_aufenthalt: 84 = Rehabilitations-abteilung/-klinik, gleicher Betrieb
 In der Variablenbeschreibung ist eine separate Einteilung der aussereuropäischen Länder in Regionen erwähnt. Existiert diese Liste bereits oder wird sie noch veröffentlicht?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
+
 - Das Vorgehen und die Liste ist gleich geblieben wie bei der MS. Anbei der Link zur Liste: [https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html](https://www.bfs.admin.ch/bfs/de/home/statistiken/gesundheit/nomenklaturen/medsreg.html)
 -	Für die aussereuropäischen Länder können Regionen erfasst werden, es können aber auch die Ländercodes angegeben werden. Dies ist bereits in der MS so und hat sich nicht geändert. Das Format ist alphanumerisch und kann somit sowohl Zahlen wie Buchstaben enthalten.
 {{</markdown>}}
@@ -101,6 +119,7 @@ Das ist tatsächlich etwas widersprüchlich formuliert. Damit hier keine Missing
 Gemäss unserer Patientenadministration wird es schwierig für die Fälle mit einer «Flex-Versicherung», die Information zu gewinnen und mit «8 = andere» zu hinterlegen. Gibt es bei den Auswertungen später ein Problem bzw. welche Auswirkungen ergeben sich auf die Statistik, wenn wir «8=andere» nicht angeben (können)?
 {{<collapsibleBlock groupId="admninistratives">}}
 {{<markdown>}}
+
 -	Die Flex-Fälle und alle anderen Versicherungsmodelle, die immer populärer werden, sind wirklich nicht ganz einfach abzubilden. Bei der Versicherungsklasse ist das eine Herausforderung aber nicht weiter dramatisch für die Statistik. Im Zweifelsfall sollten diese Fälle als Halbprivat abgebildet werden.
 -	Die Variable «liegeklasse» ist hingegen zentral für die Abbildung des ITAR_K. Da gibt es auch keine Kategorie «andere» und Fälle mit «unbekannt» werden wir genau prüfen. Je nach Ausprägung dieser Variable, werden die Fälle in ITAR_K einer anderen Spalte zugeordnet.
 {{</markdown>}}

--- a/layouts/shortcodes/unorderedList.html
+++ b/layouts/shortcodes/unorderedList.html
@@ -1,0 +1,32 @@
+{{/* Generates an unordered list with optional custom classes.
+
+  This shortcode creates an unordered list (`<ul>`) HTML element, allowing the user
+  to add custom classes for styling purposes.
+
+  The main reason of providing this shortcode is that using markdown unordered list doesn't work well
+  when shortcodes are used inside an item. Indeed, the HTML result could contain more than one <ul> element.
+
+  Parameters:
+  - class: A string containing one or more CSS class names to be added to the `<ul>` element.
+  This parameter is optional and defaults to an empty string if not provided.
+
+  Example:
+  To use this shortcode in your content, you can include it like this:
+  {{<unorderedList
+>}}
+
+{{< listItem >}}
+Wen kontaktiert das Spital, wenn es inhaltliche Fragen betreffend der SpiGes
+Erhebung hat?
+{{< collapsibleBlock groupId="Rollen" >}}
+Bei fachlichen oder technischen Fragen zur SpiGes wendet sich das Spital primär
+an seine zuständige kantonale Erhebungsstelle.
+{{< /collapsibleBlock >}}
+{{< /listItem >}}
+...
+{{< /unorderedList >}}
+*/}}
+{{ $class := .Get "class" | default "" }}
+<ul class="unordered-list {{ $class }}">
+  {{ .Inner }}
+</ul>


### PR DESCRIPTION
- New shortcode `UnorderedList` added
- Example of usage in de->FAQ->Falldaten->1_administratives.md
 
Implementation before:
```
{{<markdown>}}

-	Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden: [https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf](https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf)
-	Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital.
-	Gemäss SwissDRG AG wird Rückverlegung nur genutzt als Eintrittsart, wenn der Patient >18 Tage in einem anderen Spital war und wieder zurückkommt und somit ein neuer Fall eröffnet wird.
-	Ein Patient, der nach <18 Tage ins Spital zurückkommt, erhält die Eintrittsart-Angabe seines 1. Eintritts, weil er ja zusammengelegt wird.
{{</markdown>}}
```

Implementation after:
```
{{<unorderedList>}}

{{<listItem>}}
Die Variable Eintrittsart existiert bereits in der MS und hat sich mit SpiGes auch nicht verändert. Eine Verlegung grenzt sich vom internen Übertritt dadurch ab, dass diese nicht im gleichen Spital (BURGESV) geschieht, sondern spitalübergreifend (zwei unterschiedliche BURGESV). Die Definition richtet sich nach den Grundsätzen der SwissDRG AG, welche Sie hier finden:  
{{<link url="https://www.swissdrg.org/application/files/7416/7051/1936/Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf" newTab="true">}}Klarstellungen_und_Fallbeispiele_zu_den_Anwendungsregeln_Version_4.7.pdf{{</link>}}
{{</listItem>}}

{{<listItem>}}
Bei der Eintrittsart «6=Rückverlegung» wurde von der SwissDRG AG folgende Spezifizierung kommuniziert: Bei ununterbrochenem Spitalaufenthalt in einem anderen Spital von mehr als 18 Tagen und Rückkehr in das ursprüngliche Spital.
{{</listItem>}}

{{<listItem>}}
Gemäss SwissDRG AG wird Rückverlegung nur genutzt als Eintrittsart, wenn der Patient >18 Tage in einem anderen Spital war und wieder zurückkommt und somit ein neuer Fall eröffnet wird.
{{</listItem>}}

{{<listItem>}}
Ein Patient, der nach <18 Tage ins Spital zurückkommt, erhält die Eintrittsart-Angabe seines 1. Eintritts, weil er ja zusammengelegt wird.
{{</listItem>}}

{{</unorderedList>}}
```

Visual result:
![image](https://github.com/user-attachments/assets/3fbb0954-a1c3-40ff-bcf8-283707a12ad1)

HTML result:
![image](https://github.com/user-attachments/assets/b478300e-111c-4f40-b116-f1546984fb45)

