### PR TITLE
Rc 183 check git tag step bug

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "Error: Workflow must be run on the 'main' branch."
-            exit 1
+            exit 0
           fi
 
   extract_release_version:
@@ -82,7 +82,7 @@ jobs:
   build:
     needs: [check_git_tag, read-tool-versions]
     runs-on: ubuntu-latest
-    if: always() && success()
+    if: false && always() && success()
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -134,6 +134,7 @@ jobs:
 
   deploy:
     needs: [build]
+    if: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -145,7 +146,8 @@ jobs:
         uses: actions/deploy-pages@v4
 
   create-release:
-    needs: [deploy, extract_release_version]
+    #needs: [deploy, extract_release_version]
+    needs: [extract_release_version]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -134,12 +134,11 @@ jobs:
 
   deploy:
     needs: [build]
-    if: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: always() && success()
+    if: false && always() && success()
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "Error: Workflow must be run on the 'main' branch."
-            exit 0
+            exit 1
           fi
 
   extract_release_version:
@@ -82,7 +82,7 @@ jobs:
   build:
     needs: [check_git_tag, read-tool-versions]
     runs-on: ubuntu-latest
-    if: false && always() && success()
+    if: always() && success()
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,15 +138,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: false && always() && success()
+    if: always() && success()
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
 
   create-release:
-    #needs: [deploy, extract_release_version]
-    needs: [extract_release_version]
+    needs: [deploy]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -165,7 +164,7 @@ jobs:
           gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --notes-file RELEASE_NOTES.md --draft
 
   publish-release:
-    needs: [create-release, extract_release_version]
+    needs: [create-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -50,7 +50,7 @@ jobs:
             echo "Release version is empty. Stopping the workflow."
             exit 1
           else
-            echo "release_version=$release_version" >> $GITHUB_OUTPUT
+            echo "release_version=v$release_version" >> $GITHUB_OUTPUT
           fi
 
   check_git_tag:
@@ -161,7 +161,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "release version = $RELEASE_VERSION"
-          gh release create "v$RELEASE_VERSION" --title "Release $RELEASE_VERSION" --notes-file RELEASE_NOTES.md --draft
+          gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --notes-file RELEASE_NOTES.md --draft
 
   publish-release:
     needs: [create-release, extract_release_version]
@@ -179,4 +179,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "release version = $RELEASE_VERSION"
-          gh release edit "v$RELEASE_VERSION" --draft=false
+          gh release edit "$RELEASE_VERSION" --draft=false

--- a/hugo.toml
+++ b/hugo.toml
@@ -116,7 +116,7 @@ baseName = 'handbook'
 
 # The version number of the docs. It should correspond to the version of SpiGes but could also be decorrelated. MUSTN'T BE EMPTY!
 # and MUST BE INCREASED at each release!
-version = "0.7"
+version = "0.8"
 
 # Datetime of the build intended to be set by the CI, LEAVE EMPTY HERE!
 buildDatetime = ""

--- a/hugo.toml
+++ b/hugo.toml
@@ -116,7 +116,7 @@ baseName = 'handbook'
 
 # The version number of the docs. It should correspond to the version of SpiGes but could also be decorrelated. MUSTN'T BE EMPTY!
 # and MUST BE INCREASED at each release!
-version = "0.8"
+version = "0.7"
 
 # Datetime of the build intended to be set by the CI, LEAVE EMPTY HERE!
 buildDatetime = ""


### PR DESCRIPTION
- `extract_release_version` job updated by adding a `v` prefix to the release version (after extraction from the hugo.toml file).
- The title of a release is now the name of the tag (for instance `v0.7)`. The `Release` word is removed.