### PR TITLE
[#212] - Useless text in SpiGes release notes model removed

### DIFF
--- a/content/de/release_notes/_2024.11.08.md
+++ b/content/de/release_notes/_2024.11.08.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/de/release_notes/_2024.12.09.md
+++ b/content/de/release_notes/_2024.12.09.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/de/release_notes/_2025.01.22.md
+++ b/content/de/release_notes/_2025.01.22.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/de/release_notes/_2025.02.10.md
+++ b/content/de/release_notes/_2025.02.10.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/fr/release_notes/_2024.11.08.md
+++ b/content/fr/release_notes/_2024.11.08.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/fr/release_notes/_2024.12.09.md
+++ b/content/fr/release_notes/_2024.12.09.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/fr/release_notes/_2025.01.22.md
+++ b/content/fr/release_notes/_2025.01.22.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/content/fr/release_notes/_2025.02.10.md
+++ b/content/fr/release_notes/_2025.02.10.md
@@ -7,7 +7,7 @@ type: docs
 keywords: []
 ---
 
-{{<releaseNotes responsible="Stefan Neubert">}}
+{{<releaseNotes>}}
 
 {{<releaseNotes/improvements>}}
 {{<markdown>}}

--- a/layouts/shortcodes/releaseNotes.html
+++ b/layouts/shortcodes/releaseNotes.html
@@ -1,3 +1,6 @@
+{{ $responsible := .Get "responsible" | default "" }}
+
+
 <div class="release-notes">
   <h2>
     {{ T "release_notes_title" }}
@@ -6,13 +9,11 @@
 
   </h2>
   <br />
-  <p>{{ T "release_notes_dear_text" }}</p>
   <p>{{ T "release_notes_new_version_text" }}</p>
 
   {{ .Inner }}
 
 
   <br />
-  <p>{{ T "release_notes_thanks_text" }}</p>
-  <p>{{ .Get "responsible" }}</p>
+  <p>{{ $responsible }}</p>
 </div>


### PR DESCRIPTION
The following has been removed:
- dear text
- thank text
- responsible